### PR TITLE
[chore] Centralize Website Copy

### DIFF
--- a/src/components/LocationAutocomplete.tsx
+++ b/src/components/LocationAutocomplete.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { Input } from "@/components/ui/input";
 import { MapPin, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { TEXT } from "@/constants/text";
 
 interface LocationSuggestion {
   place_id: number;
@@ -20,7 +21,7 @@ interface LocationAutocompleteProps {
 export const LocationAutocomplete = ({
   value,
   onChange,
-  placeholder = "Search for a location...",
+  placeholder = TEXT.locationAutocomplete.placeholder,
   id,
 }: LocationAutocompleteProps) => {
   const [suggestions, setSuggestions] = useState<LocationSuggestion[]>([]);

--- a/src/components/QRCodeDialog.tsx
+++ b/src/components/QRCodeDialog.tsx
@@ -8,6 +8,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Download } from "lucide-react";
 import QRCodePreview from "@/components/QRCodePreview";
+import { TEXT } from "@/constants/text";
 
 interface QRCodeDialogProps {
   open: boolean;
@@ -49,13 +50,12 @@ export const QRCodeDialog = ({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="text-center text-2xl">
-            Event QR Code
+            {TEXT.qrCodeDialog.title}
           </DialogTitle>
         </DialogHeader>
         <div className="space-y-6 py-4">
           <p className="text-center text-muted-foreground">
-            Use this QR code to allow attendees to seamlessly register
-            attendance
+            {TEXT.qrCodeDialog.description}
           </p>
 
           {open && (
@@ -75,7 +75,7 @@ export const QRCodeDialog = ({
             disabled={!qrCodeUrl}
           >
             <Download className="h-4 w-4 mr-2" />
-            Download QR Code
+            {TEXT.common.buttons.downloadQrCode}
           </Button>
         </div>
       </DialogContent>

--- a/src/components/QRCodePreview.tsx
+++ b/src/components/QRCodePreview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { TEXT } from "@/constants/text";
 
 interface QRCodePreviewProps {
   value: string;
@@ -70,7 +71,7 @@ const QRCodePreview = ({
       {dataUrl ? (
         <img
           src={dataUrl}
-          alt="QR Code"
+          alt={TEXT.qrCodePreview.alt}
           className={cn("h-64 w-64", imageClassName)}
         />
       ) : (
@@ -81,7 +82,7 @@ const QRCodePreview = ({
               imageClassName,
             )}
           >
-            Generating QR code...
+            {TEXT.qrCodePreview.generating}
           </div>
         )
       )}

--- a/src/components/QRScanner.tsx
+++ b/src/components/QRScanner.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Camera } from "lucide-react";
 import { toast } from "sonner";
+import { TEXT } from "@/constants/text";
 
 type Html5QrcodeType = import("html5-qrcode").Html5Qrcode;
 
@@ -113,11 +114,11 @@ export const QRScanner = ({ open, onClose, onScan }: QRScannerProps) => {
         onScan(slug);
         onClose();
       } else {
-        toast.error("Invalid event QR code");
+        toast.error(TEXT.qrScannerErrors.invalidQr);
       }
     } catch (err) {
       console.error("Error parsing QR code:", err);
-      toast.error("Invalid QR code format");
+      toast.error(TEXT.qrScannerErrors.invalidFormat);
     }
   };
 
@@ -132,12 +133,12 @@ export const QRScanner = ({ open, onClose, onScan }: QRScannerProps) => {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Camera className="h-5 w-5" />
-            Scan Event QR Code
+            {TEXT.qrScanner.title}
           </DialogTitle>
           <DialogDescription className="sr-only">
             {hasPermission === false
-              ? "Camera access denied. Please enable camera permissions in your browser settings."
-              : "Position the QR code within the frame to scan"}
+              ? TEXT.qrScanner.permissionDenied
+              : TEXT.qrScanner.instructions}
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
@@ -145,8 +146,7 @@ export const QRScanner = ({ open, onClose, onScan }: QRScannerProps) => {
             <div className="rounded-lg border border-border bg-muted/30 p-6 text-center">
               <Camera className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
               <p className="text-sm text-muted-foreground">
-                Camera access denied. Please enable camera permissions in your
-                browser settings.
+                {TEXT.qrScanner.permissionDenied}
               </p>
             </div>
           ) : (
@@ -159,11 +159,11 @@ export const QRScanner = ({ open, onClose, onScan }: QRScannerProps) => {
           )}
           {hasPermission !== false && (
             <p className="text-sm text-muted-foreground text-center">
-              Position the QR code within the frame to scan
+              {TEXT.qrScanner.instructions}
             </p>
           )}
           <Button variant="outline" onClick={onClose} className="w-full">
-            Cancel
+            {TEXT.common.buttons.cancel}
           </Button>
         </div>
       </DialogContent>

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -3,6 +3,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { ChevronRight, MoreHorizontal } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { TEXT } from "@/constants/text";
 
 const Breadcrumb = React.forwardRef<
   HTMLElement,
@@ -99,7 +100,7 @@ const BreadcrumbEllipsis = ({
     {...props}
   >
     <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More</span>
+    <span className="sr-only">{TEXT.common.ui.breadcrumbMore}</span>
   </span>
 );
 BreadcrumbEllipsis.displayName = "BreadcrumbElipssis";

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, ArrowRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { TEXT } from "@/constants/text";
 
 type CarouselApi = UseEmblaCarouselType[1];
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
@@ -215,7 +216,7 @@ const CarouselPrevious = React.forwardRef<
       {...props}
     >
       <ArrowLeft className="h-4 w-4" />
-      <span className="sr-only">Previous slide</span>
+      <span className="sr-only">{TEXT.common.ui.carouselPrevious}</span>
     </Button>
   );
 });
@@ -244,7 +245,7 @@ const CarouselNext = React.forwardRef<
       {...props}
     >
       <ArrowRight className="h-4 w-4" />
-      <span className="sr-only">Next slide</span>
+      <span className="sr-only">{TEXT.common.ui.carouselNext}</span>
     </Button>
   );
 });

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,6 +3,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { TEXT } from "@/constants/text";
 
 const Dialog = DialogPrimitive.Root;
 
@@ -44,7 +45,7 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-accent data-[state=open]:text-muted-foreground hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">{TEXT.common.ui.close}</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { ButtonProps, buttonVariants } from "@/components/ui/button";
+import { TEXT } from "@/constants/text";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav
@@ -64,13 +65,13 @@ const PaginationPrevious = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to previous page"
+    aria-label={TEXT.common.ui.paginationPreviousLabel}
     size="default"
     className={cn("gap-1 pl-2.5", className)}
     {...props}
   >
     <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
+    <span>{TEXT.common.ui.paginationPrevious}</span>
   </PaginationLink>
 );
 PaginationPrevious.displayName = "PaginationPrevious";
@@ -80,12 +81,12 @@ const PaginationNext = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to next page"
+    aria-label={TEXT.common.ui.paginationNextLabel}
     size="default"
     className={cn("gap-1 pr-2.5", className)}
     {...props}
   >
-    <span>Next</span>
+    <span>{TEXT.common.ui.paginationNext}</span>
     <ChevronRight className="h-4 w-4" />
   </PaginationLink>
 );
@@ -101,7 +102,7 @@ const PaginationEllipsis = ({
     {...props}
   >
     <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More pages</span>
+    <span className="sr-only">{TEXT.common.ui.paginationMore}</span>
   </span>
 );
 PaginationEllipsis.displayName = "PaginationEllipsis";

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { TEXT } from "@/constants/text";
 
 const Sheet = SheetPrimitive.Root;
 
@@ -65,7 +66,7 @@ const SheetContent = React.forwardRef<
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">{TEXT.common.ui.close}</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TEXT } from "@/constants/text";
 import {
   Tooltip,
   TooltipContent,
@@ -285,7 +286,7 @@ const SidebarTrigger = React.forwardRef<
       {...props}
     >
       <PanelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
+        <span className="sr-only">{TEXT.common.ui.toggleSidebar}</span>
     </Button>
   );
 });

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1,0 +1,361 @@
+export const TEXT = {
+  common: {
+    brand: "LinkBack",
+    copy: {
+      footer: "© 2025 LinkBack. Powered by LinkedIn.",
+    },
+    buttons: {
+      signInWithLinkedIn: "Sign in with LinkedIn",
+      joinEvent: "Join an Event",
+      hostEvent: "Host an Event",
+      howItWorks: "How It Works",
+      myEvents: "My Events",
+      getStarted: "Get Started",
+      signIn: "Sign In",
+      createFirstEvent: "Create Your First Event",
+      scanQrCode: "Scan QR Code",
+      joinByCode: "Join by Code",
+      goToDashboard: "Go to Dashboard",
+      continueCheckIn: "Continue to Check-In",
+      findingEvent: "Finding Event...",
+      createEventAndQr: "Create Event & Generate QR Code",
+      creatingEvent: "Creating Event...",
+      downloadQrCode: "Download QR Code",
+      viewEventDashboard: "View Event Dashboard",
+      tryLinkBackNow: "Try LinkBack Now",
+      viewQrCode: "View QR Code",
+      cancel: "Cancel",
+    },
+    links: {
+      backToDashboard: "Back to Dashboard",
+      backToHome: "Back to Home",
+      viewPastEvents: "View your past events",
+      returnHome: "Return to Home",
+      backToHomeArrow: "← Back to home",
+    },
+    labels: {
+      eventCode: "Event Code",
+      dateNotSet: "Date not set",
+    },
+    ui: {
+      breadcrumbMore: "More",
+      carouselPrevious: "Previous slide",
+      carouselNext: "Next slide",
+      paginationPrevious: "Previous",
+      paginationNext: "Next",
+      paginationMore: "More pages",
+      paginationPreviousLabel: "Go to previous page",
+      paginationNextLabel: "Go to next page",
+      close: "Close",
+      toggleSidebar: "Toggle Sidebar",
+    },
+  },
+  landing: {
+    hero: {
+      titleLine: "Event Check-In,",
+      highlight: "Simplified.",
+      authenticatedDescription:
+        "Streamline your event networking with LinkedIn integration. Check in instantly, connect with attendees, and build your professional network effortlessly.",
+      guestDescription:
+        "Create a QR code for your event. Attendees scan to check in with LinkedIn. Build verified attendee lists instantly.",
+      joinButton: "Join an Event",
+      hostButton: "Host an Event",
+      demoButton: "How It Works",
+      signInButton: "Sign in with LinkedIn",
+    },
+    features: {
+      oneQrCode: {
+        title: "One QR Code",
+        description:
+          "Generate a unique QR code for each event. Display it at your venue or share the link.",
+      },
+      linkedinVerified: {
+        title: "LinkedIn Verified",
+        description:
+          "Authentic attendee data from LinkedIn. No fake accounts, just real professionals.",
+      },
+      instantLists: {
+        title: "Instant Lists",
+        description:
+          "View who attended in real-time. Names, headlines, and profile links at your fingertips.",
+      },
+    },
+    howItWorks: {
+      title: "How It Works",
+      steps: [
+        {
+          step: "1",
+          title: "Create Your Event",
+          description:
+            "Sign up as an organizer and create your event in seconds. Get a unique QR code instantly.",
+        },
+        {
+          step: "2",
+          title: "Attendees Check In",
+          description:
+            "Guests scan the QR code and authenticate with LinkedIn. Their attendance is recorded automatically.",
+        },
+        {
+          step: "3",
+          title: "View Attendee List",
+          description:
+            "Access the complete list of verified attendees with their LinkedIn profiles, names, and headlines.",
+        },
+      ],
+    },
+    footerCta: {
+      title: "Ready to streamline your events?",
+      description: "Join LinkBack today and start building verified attendee lists.",
+    },
+  },
+  dashboard: {
+    header: {
+      welcomePrefix: "Welcome back,",
+      tagline: "Host events, check in to events, and connect with attendees.",
+      signOutSuccess: "Signed out successfully",
+    },
+    loading: "Loading your dashboard...",
+    myEvents: {
+      title: "Your Events",
+      loading: "Loading your events...",
+      emptyTitle: "Ready to host your first event?",
+      emptyDescription: "Create your QR in under 10 seconds.",
+      viewAttendees: "View attendees →",
+    },
+    upcoming: {
+      title: "Events You've Attended",
+      loading: "Loading your upcoming events...",
+      emptyTitle: "No check-ins yet.",
+      emptyDescription: "Scan a QR or enter a 6-digit code to get started.",
+      viewAttendeeList: "View attendee list →",
+    },
+    toast: {
+      authRequired: "Please sign in to check in",
+      alreadyCheckedIn: "You're already checked in to this event!",
+    },
+  },
+  demo: {
+    header: {
+      title: "See LinkBack in Action",
+      subtitle: "Experience how easy event check-ins can be",
+    },
+    showcase: {
+      steps: [
+        {
+          title: "Organizer Creates Event",
+          description:
+            "Sign up as an organizer, create your event with a name and optional details",
+          checklist: [
+            'Enter event name: "Tech Meetup 2025"',
+            "Set date and time (optional)",
+            "Add LinkedIn event URL (optional)",
+            "Get unique QR code instantly",
+          ],
+        },
+        {
+          title: "Display QR Code",
+          description:
+            "Print the QR code or display it digitally at your event entrance",
+          note: "Each event gets a unique QR code",
+        },
+        {
+          title: "Attendees Check In",
+          description:
+            "Guests scan the QR code with their phone and authenticate with LinkedIn",
+          privacyNotice: "⚠️ Privacy Notice Shown:",
+          privacyCopy:
+            '"Your LinkedIn name and headline will be shown to other attendees of this event."',
+          confirmation: "Attendance recorded automatically",
+        },
+        {
+          title: "View Attendee List",
+          description:
+            "Organizers and attendees can see the verified list of who's at the event",
+          attendees: [
+            {
+              name: "Sarah Johnson",
+              title: "Senior Product Manager at Tech Corp",
+            },
+            {
+              name: "Michael Chen",
+              title: "Software Engineer at StartupXYZ",
+            },
+            {
+              name: "Emma Davis",
+              title: "UX Designer at Creative Studio",
+            },
+          ],
+        },
+      ],
+    },
+    notes: {
+      helper: "No payments. No friction. Simply login and start scanning.",
+    },
+  },
+  createEvent: {
+    header: {
+      backToDashboard: "Back to Dashboard",
+      backToHome: "Back to Home",
+    },
+    form: {
+      title: "Create New Event",
+      description: "Fill in the details below to generate your event QR code",
+      fields: {
+        nameLabel: "Event Name *",
+        namePlaceholder: "Summer Tech Meetup 2025",
+        locationLabel: "Location",
+        locationPlaceholder: "TechHub Conference Center, San Francisco",
+        startsAtLabel: "Start Date & Time",
+        linkedinUrlLabel: "LinkedIn Event URL (optional)",
+        linkedinUrlPlaceholder: "https://www.linkedin.com/events/...",
+      },
+      submitIdle: "Create Event & Generate QR Code",
+      submitLoading: "Creating Event...",
+    },
+    toast: {
+      success: "Event created successfully!",
+      failure: "Failed to create event",
+      authRequired: "Please sign in to create events",
+    },
+  },
+  joinEvent: {
+    header: {
+      title: "Join an Event",
+      description: "Enter your numeric event code to check in",
+    },
+    alert: {
+      organizer: "You are the host of this event. Visit your dashboard to see the event details.",
+    },
+    form: {
+      label: "Event Code",
+      placeholder: "Enter 6-digit code",
+      goToDashboard: "Go to Dashboard",
+      submitIdle: "Continue to Check-In",
+      submitLoading: "Finding Event...",
+      helperText: "You can also scan a QR code at the event entrance",
+    },
+    toast: {
+      missingCode: "Please enter an event code",
+      notFound: "Event not found. Please check the code and try again.",
+      failure: "Failed to find event. Please try again.",
+    },
+  },
+  auth: {
+    brand: "LinkBack",
+    tagline: "Professional event check-in",
+    card: {
+      title: "Sign in with LinkedIn",
+      description: "Authenticate securely using your LinkedIn account",
+      buttonIdle: "Continue with LinkedIn",
+      buttonLoading: "Connecting to LinkedIn...",
+    },
+    info: {
+      title: "What we access:",
+      items: [
+        {
+          title: "Your name and profile picture",
+          description: "To identify you at events",
+        },
+        {
+          title: "Your headline and email",
+          description: "For professional networking",
+        },
+        {
+          title: "Read-only access",
+          description: "We cannot post or message on your behalf",
+        },
+      ],
+      consentPrefix:
+        "By signing in, you agree to share your LinkedIn profile information with event organizers and attendees for networking purposes. You can revoke access anytime from your",
+      linkedInSettings: "LinkedIn settings.",
+    },
+    navigation: {
+      backToHome: "← Back to home",
+    },
+    toast: {
+      failure: "Authentication failed",
+    },
+  },
+  authCallback: {
+    loadingTitle: "Authenticating...",
+    loadingDescription: "Please wait while we complete your sign in",
+    errorTitle: "Authentication Error",
+    errorDescription: "Redirecting you back to sign in...",
+    toast: {
+      sessionFailure: "Failed to establish session",
+      noSession: "No active session found",
+      loadProfileFailure: "Failed to load profile",
+      success: "Successfully authenticated!",
+      genericFailure: "Authentication failed",
+    },
+  },
+  event: {
+    header: {
+      hostedBy: "Hosted by",
+      viewProfile: "View Profile",
+      viewSelfProfile: "View Your Profile",
+      linkedInMissing: "LinkedIn profile not available",
+      checkedIn: "You're checked in!",
+    },
+    attendButton: {
+      checkingIn: "Checking In...",
+      checkInLinkedIn: "Check In with LinkedIn",
+      checkIn: "Check In to This Event",
+    },
+    attendeeList: {
+      singular: "Attendee",
+      plural: "Attendees",
+      loading: "Loading attendees...",
+      organizerEmpty: "No attendees yet. Share your QR code to get people to check in!",
+      attendeeEmpty: "No attendees yet. Be the first to check in!",
+    },
+    page: {
+      loading: "Loading event...",
+      notFoundTitle: "Event Not Found",
+      notFoundDescription: "The event you're looking for doesn't exist.",
+      homeButton: "Go Home",
+      guestNotice:
+        "By checking in, you agree to share your LinkedIn profile information with event attendees for networking purposes.",
+      signInPrompt: "Sign In",
+      backToDashboard: "Back to Dashboard",
+    },
+    toast: {
+      loadFailure: "Failed to load event",
+      checkInSuccess: "Checked in successfully!",
+      checkInFailure: "Failed to check in",
+      alreadyCheckedIn: "You're already checked in!",
+      eventNotFound: "Event not found",
+    },
+  },
+  eventSuccess: {
+    loading: "Loading...",
+    title: "Event Created!",
+    description: "Your event is ready. Share the QR code or event code with attendees.",
+    codeLabel: "Event Code",
+  },
+  qrScanner: {
+    title: "Scan Event QR Code",
+    permissionDenied: "Camera access denied. Please enable camera permissions in your browser settings.",
+    instructions: "Position the QR code within the frame to scan",
+  },
+  qrCodeDialog: {
+    title: "Event QR Code",
+    description: "Use this QR code to allow attendees to seamlessly register attendance",
+  },
+  qrCodePreview: {
+    alt: "QR Code",
+    generating: "Generating QR code...",
+  },
+  locationAutocomplete: {
+    placeholder: "Search for a location...",
+  },
+  notFound: {
+    title: "404",
+    subtitle: "Oops! Page not found",
+    link: "Return to Home",
+  },
+  qrScannerErrors: {
+    invalidQr: "Invalid event QR code",
+    invalidFormat: "Invalid QR code format",
+  },
+};

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -11,10 +11,13 @@ import {
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { QrCode, Linkedin, Shield, Users, Lock } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
 const Auth = () => {
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
+  const infoItems = TEXT.auth.info.items;
+  const infoIcons = [Users, Shield, Lock];
 
   useEffect(() => {
     // Check if user is already authenticated
@@ -38,7 +41,7 @@ const Auth = () => {
 
       if (error) throw error;
     } catch (error: any) {
-      toast.error(error.message || "Authentication failed");
+      toast.error(error.message || TEXT.auth.toast.failure);
       setIsLoading(false);
     }
   };
@@ -49,18 +52,16 @@ const Auth = () => {
         <div className="text-center mb-8">
           <Link to="/" className="inline-flex items-center gap-2 mb-4">
             <QrCode className="h-10 w-10 text-primary" />
-            <span className="text-3xl font-bold">LinkBack</span>
+            <span className="text-3xl font-bold">{TEXT.auth.brand}</span>
           </Link>
-          <p className="text-xl text-muted-foreground">
-            Professional event check-in
-          </p>
+          <p className="text-xl text-muted-foreground">{TEXT.auth.tagline}</p>
         </div>
 
         <Card className="border-border shadow-xl">
           <CardHeader className="space-y-2 text-center pb-6">
-            <CardTitle className="text-2xl">Sign in with LinkedIn</CardTitle>
+            <CardTitle className="text-2xl">{TEXT.auth.card.title}</CardTitle>
             <p className="text-sm text-muted-foreground">
-              Authenticate securely using your LinkedIn account
+              {TEXT.auth.card.description}
             </p>
           </CardHeader>
 
@@ -74,63 +75,43 @@ const Auth = () => {
               {isLoading ? (
                 <>
                   <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
-                  Connecting to LinkedIn...
+                  {TEXT.auth.card.buttonLoading}
                 </>
               ) : (
                 <>
                   <Linkedin className="h-5 w-5 mr-2" />
-                  Continue with LinkedIn
+                  {TEXT.auth.card.buttonIdle}
                 </>
               )}
             </Button>
 
             <div className="space-y-4 pt-4 border-t border-border">
               <p className="text-sm font-medium text-center text-foreground">
-                What we access:
+                {TEXT.auth.info.title}
               </p>
 
               <div className="space-y-3">
-                <div className="flex items-start gap-3">
-                  <Users className="h-5 w-5 text-primary flex-shrink-0 mt-0.5" />
-                  <div>
-                    <p className="text-sm font-medium">
-                      Your name and profile picture
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      To identify you at events
-                    </p>
-                  </div>
-                </div>
+                {infoItems.map((item, index) => {
+                  const Icon = infoIcons[index] ?? Users;
 
-                <div className="flex items-start gap-3">
-                  <Shield className="h-5 w-5 text-primary flex-shrink-0 mt-0.5" />
-                  <div>
-                    <p className="text-sm font-medium">
-                      Your headline and email
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      For professional networking
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-start gap-3">
-                  <Lock className="h-5 w-5 text-primary flex-shrink-0 mt-0.5" />
-                  <div>
-                    <p className="text-sm font-medium">Read-only access</p>
-                    <p className="text-xs text-muted-foreground">
-                      We cannot post or message on your behalf
-                    </p>
-                  </div>
-                </div>
+                  return (
+                    <div key={item.title} className="flex items-start gap-3">
+                      <Icon className="h-5 w-5 text-primary flex-shrink-0 mt-0.5" />
+                      <div>
+                        <p className="text-sm font-medium">{item.title}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {item.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
 
             <div className="pt-2">
               <p className="text-xs text-center text-muted-foreground leading-relaxed">
-                By signing in, you agree to share your LinkedIn profile
-                information with event organizers and attendees for networking
-                purposes. You can revoke access anytime from your{" "}
+                {TEXT.auth.info.consentPrefix}{" "}
                 <a
                   href="https://www.linkedin.com/mypreferences/d/apps"
                   target="_blank"
@@ -138,9 +119,8 @@ const Auth = () => {
                   className="hover:underline"
                   style={{ color: "#0A66C2" }}
                 >
-                  LinkedIn settings
+                  {TEXT.auth.info.linkedInSettings}
                 </a>
-                .
               </p>
             </div>
           </CardContent>
@@ -151,7 +131,7 @@ const Auth = () => {
             to="/"
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            ← Back to home
+            {TEXT.auth.navigation.backToHome}
           </Link>
         </div>
       </div>

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -4,6 +4,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useMyProfile } from "@/hooks/useSupabaseData";
 import { toast } from "sonner";
 import { QrCode } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
 const AuthCallback = () => {
   const navigate = useNavigate();
@@ -26,7 +27,7 @@ const AuthCallback = () => {
 
         if (error) {
           console.error("OAuth error:", error, errorDescription);
-          toast.error(errorDescription || "Authentication failed");
+          toast.error(errorDescription || TEXT.authCallback.toast.genericFailure);
           setStatus("error");
           setTimeout(() => navigate("/auth"), 2000);
           return;
@@ -39,14 +40,14 @@ const AuthCallback = () => {
 
         if (sessionError) {
           console.error("Session error:", sessionError);
-          toast.error("Failed to establish session");
+          toast.error(TEXT.authCallback.toast.sessionFailure);
           setStatus("error");
           setTimeout(() => navigate("/auth"), 2000);
           return;
         }
 
         if (!session) {
-          toast.error("No active session found");
+          toast.error(TEXT.authCallback.toast.noSession);
           setStatus("error");
           setTimeout(() => navigate("/auth"), 2000);
           return;
@@ -55,7 +56,11 @@ const AuthCallback = () => {
         setUserId(session.user.id);
       } catch (error: unknown) {
         console.error("Auth callback error:", error);
-        toast.error(error instanceof Error ? error.message : "Authentication failed");
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : TEXT.authCallback.toast.genericFailure,
+        );
         setStatus("error");
         setTimeout(() => navigate("/auth"), 2000);
       }
@@ -71,14 +76,14 @@ const AuthCallback = () => {
 
     if (profileError) {
       console.error("Profile fetch error:", profileError);
-      toast.error("Failed to load profile");
+      toast.error(TEXT.authCallback.toast.loadProfileFailure);
       setStatus("error");
       setHasHandledProfile(true);
       setTimeout(() => navigate("/auth"), 2000);
       return;
     }
 
-    toast.success("Successfully authenticated!");
+    toast.success(TEXT.authCallback.toast.success);
     setHasHandledProfile(true);
     navigate("/dashboard");
   }, [hasHandledProfile, isProfileLoading, navigate, profileError, userId]);
@@ -92,9 +97,11 @@ const AuthCallback = () => {
 
         {status === "loading" ? (
           <>
-            <h1 className="text-2xl font-bold">Authenticating...</h1>
+            <h1 className="text-2xl font-bold">
+              {TEXT.authCallback.loadingTitle}
+            </h1>
             <p className="text-muted-foreground">
-              Please wait while we complete your sign in
+              {TEXT.authCallback.loadingDescription}
             </p>
             <div className="flex justify-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
@@ -103,10 +110,10 @@ const AuthCallback = () => {
         ) : (
           <>
             <h1 className="text-2xl font-bold text-destructive">
-              Authentication Error
+              {TEXT.authCallback.errorTitle}
             </h1>
             <p className="text-muted-foreground">
-              Redirecting you back to sign in...
+              {TEXT.authCallback.errorDescription}
             </p>
           </>
         )}

--- a/src/pages/CreateEvent.tsx
+++ b/src/pages/CreateEvent.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { TEXT } from "@/constants/text";
 import { useCreateEvent } from "@/hooks/useSupabaseData";
 import CreateEventHeader from "./create-event/components/CreateEventHeader";
 import CreateEventForm from "./create-event/components/CreateEventForm";
@@ -19,7 +20,9 @@ const CreateEvent = () => {
   // Check if coming from dashboard, default to home
   const fromDashboard = routerLocation.state?.fromDashboard;
   const backPath = fromDashboard ? "/dashboard" : "/";
-  const backText = fromDashboard ? "Back to Dashboard" : "Back to Home";
+  const backText = fromDashboard
+    ? TEXT.createEvent.header.backToDashboard
+    : TEXT.createEvent.header.backToHome;
 
   const generateSlug = (name: string) => {
     return (
@@ -42,7 +45,7 @@ const CreateEvent = () => {
       } = await supabase.auth.getSession();
 
       if (!session) {
-        toast.error("Please sign in to create events");
+        toast.error(TEXT.createEvent.toast.authRequired);
         navigate("/auth");
         return;
       }
@@ -58,10 +61,10 @@ const CreateEvent = () => {
         organizer_id: session.user.id,
       });
 
-      toast.success("Event created successfully!");
+      toast.success(TEXT.createEvent.toast.success);
       navigate(`/event-success/${slug}`);
     } catch (error: any) {
-      toast.error(error.message || "Failed to create event");
+      toast.error(error.message || TEXT.createEvent.toast.failure);
     } finally {
       setIsLoading(false);
     }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { QRScanner } from "@/components/QRScanner";
 import { useQueryClient } from "@tanstack/react-query";
+import { TEXT } from "@/constants/text";
 import {
   fetchEventWithClient,
   useMyEvents,
@@ -84,7 +85,7 @@ const Dashboard = () => {
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();
-    toast.success("Signed out successfully");
+    toast.success(TEXT.dashboard.header.signOutSuccess);
     navigate("/");
   };
 
@@ -95,7 +96,7 @@ const Dashboard = () => {
       });
 
       if (!eventData) {
-        toast.error("Event not found");
+        toast.error(TEXT.event.toast.eventNotFound);
         return;
       }
 
@@ -104,7 +105,7 @@ const Dashboard = () => {
       } = await supabase.auth.getSession();
 
       if (!session) {
-        toast.error("Please sign in to check in");
+        toast.error(TEXT.dashboard.toast.authRequired);
         navigate("/auth");
         return;
       }
@@ -124,7 +125,7 @@ const Dashboard = () => {
         source: "qr",
       });
 
-      toast.success("Checked in successfully!");
+      toast.success(TEXT.event.toast.checkInSuccess);
       setShowScanner(false);
       navigate(`/event/${eventSlug}`);
     } catch (error) {
@@ -134,14 +135,14 @@ const Dashboard = () => {
         "code" in error &&
         (error as { code?: string }).code === "23505"
       ) {
-        toast.info("You're already checked in to this event!");
+        toast.info(TEXT.dashboard.toast.alreadyCheckedIn);
         setShowScanner(false);
         navigate(`/event/${eventSlug}`);
         return;
       }
 
       console.error("Error checking in:", error);
-      toast.error("Failed to check in");
+      toast.error(TEXT.event.toast.checkInFailure);
     }
   };
 
@@ -150,7 +151,7 @@ const Dashboard = () => {
       <div className="min-h-screen bg-gradient-subtle flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">Loading your dashboard...</p>
+          <p className="text-muted-foreground">{TEXT.dashboard.loading}</p>
         </div>
       </div>
     );

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -14,7 +14,14 @@ import { QRCodeDialog } from "@/components/QRCodeDialog";
 import EventHeader from "@/pages/event/components/EventHeader";
 import AttendButton from "@/pages/event/components/AttendButton";
 import AttendeeList from "@/pages/event/components/AttendeeList";
-import { useAttendances, useEvent, useJoinEvent, useMyProfile } from "@/hooks/useSupabaseData";
+import {
+  useAttendances,
+  useEvent,
+  useJoinEvent,
+  useMyProfile,
+  type ProfileRow,
+} from "@/hooks/useSupabaseData";
+import { TEXT } from "@/constants/text";
 
 const EventPage = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -63,7 +70,7 @@ const EventPage = () => {
   useEffect(() => {
     if (eventError) {
       console.error("Error loading event:", eventError);
-      toast.error("Failed to load event");
+      toast.error(TEXT.event.toast.loadFailure);
     }
   }, [eventError]);
 
@@ -121,7 +128,7 @@ const EventPage = () => {
     }
 
     if (!event?.id) {
-      toast.error("Event not found");
+      toast.error(TEXT.event.toast.eventNotFound);
       return;
     }
 
@@ -132,7 +139,7 @@ const EventPage = () => {
         source: "manual",
       });
 
-      toast.success("Checked in successfully!");
+      toast.success(TEXT.event.toast.checkInSuccess);
     } catch (error) {
       if (
         typeof error === "object" &&
@@ -140,12 +147,12 @@ const EventPage = () => {
         "code" in error &&
         (error as { code?: string }).code === "23505"
       ) {
-        toast.info("You're already checked in!");
+        toast.info(TEXT.event.toast.alreadyCheckedIn);
         return;
       }
 
       console.error("Failed to check in:", error);
-      toast.error("Failed to check in");
+      toast.error(TEXT.event.toast.checkInFailure);
     }
   };
 
@@ -154,7 +161,7 @@ const EventPage = () => {
       <div className="min-h-screen bg-gradient-subtle flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">Loading event...</p>
+          <p className="text-muted-foreground">{TEXT.event.page.loading}</p>
         </div>
       </div>
     );
@@ -165,14 +172,12 @@ const EventPage = () => {
       <div className="min-h-screen bg-gradient-subtle flex items-center justify-center">
         <Card className="max-w-md">
           <CardHeader>
-            <CardTitle>Event Not Found</CardTitle>
-            <CardDescription>
-              The event you're looking for doesn't exist.
-            </CardDescription>
+            <CardTitle>{TEXT.event.page.notFoundTitle}</CardTitle>
+            <CardDescription>{TEXT.event.page.notFoundDescription}</CardDescription>
           </CardHeader>
           <CardContent>
             <Link to="/">
-              <Button className="w-full">Go Home</Button>
+              <Button className="w-full">{TEXT.event.page.homeButton}</Button>
             </Link>
           </CardContent>
         </Card>
@@ -205,8 +210,7 @@ const EventPage = () => {
                 mode="linkedin"
               />
               <p className="text-xs text-center text-muted-foreground px-4">
-                By checking in, you agree to share your LinkedIn profile
-                information with event attendees for networking purposes.
+                {TEXT.event.page.guestNotice}
               </p>
             </div>
 
@@ -216,7 +220,7 @@ const EventPage = () => {
                   to="/dashboard"
                   className="text-sm text-primary hover:underline"
                 >
-                  View your past events
+                  {TEXT.common.links.viewPastEvents}
                 </Link>
               </div>
             )}
@@ -235,12 +239,12 @@ const EventPage = () => {
             className="flex items-center gap-2"
           >
             <QrCode className="h-8 w-8 text-primary" />
-            <span className="text-2xl font-semibold">LinkBack</span>
+            <span className="text-2xl font-semibold">{TEXT.common.brand}</span>
           </Link>
           {!currentUserId && (
             <Link to="/auth">
               <Button variant="outline" className="rounded-full">
-                Sign In
+                {TEXT.common.buttons.signIn}
               </Button>
             </Link>
           )}
@@ -253,7 +257,7 @@ const EventPage = () => {
             <Link to="/dashboard">
               <Button variant="ghost">
                 <ArrowLeft className="h-4 w-4 mr-2" />
-                Back to Dashboard
+                {TEXT.common.links.backToDashboard}
               </Button>
             </Link>
           )}

--- a/src/pages/EventSuccess.tsx
+++ b/src/pages/EventSuccess.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { CalendarCheck, Download } from "lucide-react";
 import QRCodePreview from "@/components/QRCodePreview";
 import { useEvent } from "@/hooks/useSupabaseData";
+import { TEXT } from "@/constants/text";
 
 const EventSuccess = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -61,7 +62,7 @@ const EventSuccess = () => {
       <div className="min-h-screen bg-gradient-subtle flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">Loading...</p>
+          <p className="text-muted-foreground">{TEXT.eventSuccess.loading}</p>
         </div>
       </div>
     );
@@ -84,16 +85,15 @@ const EventSuccess = () => {
 
           {/* Title and Description */}
           <div className="text-center space-y-2">
-            <h1 className="text-3xl font-bold">Event Created!</h1>
-            <p className="text-muted-foreground">
-              Your event is ready. Share the QR code or event code with
-              attendees.
-            </p>
+            <h1 className="text-3xl font-bold">{TEXT.eventSuccess.title}</h1>
+            <p className="text-muted-foreground">{TEXT.eventSuccess.description}</p>
           </div>
 
           {/* Event Code */}
           <div className="bg-muted/50 rounded-lg p-4 text-center space-y-1">
-            <p className="text-sm text-muted-foreground">Event Code</p>
+            <p className="text-sm text-muted-foreground">
+              {TEXT.eventSuccess.codeLabel}
+            </p>
             <p className="text-4xl font-bold tracking-wider">{eventCode}</p>
           </div>
 
@@ -115,12 +115,12 @@ const EventSuccess = () => {
               disabled={!qrCodeUrl}
             >
               <Download className="h-4 w-4 mr-2" />
-              Download QR Code
+              {TEXT.common.buttons.downloadQrCode}
             </Button>
 
             <Link to={`/event/${slug}`} className="block">
               <Button className="w-full rounded-full h-12 text-base font-medium">
-                View Event Dashboard
+                {TEXT.common.buttons.viewEventDashboard}
               </Button>
             </Link>
           </div>

--- a/src/pages/JoinEvent.tsx
+++ b/src/pages/JoinEvent.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useQueryClient } from "@tanstack/react-query";
 import { fetchEventsWithClient } from "@/hooks/useSupabaseData";
+import { TEXT } from "@/constants/text";
 
 const JoinEvent = () => {
   const [eventCode, setEventCode] = useState("");
@@ -28,7 +29,9 @@ const JoinEvent = () => {
   // Check if coming from dashboard, default to home
   const fromDashboard = location.state?.fromDashboard;
   const backPath = fromDashboard ? "/dashboard" : "/";
-  const backText = fromDashboard ? "Back to Dashboard" : "Back to Home";
+  const backText = fromDashboard
+    ? TEXT.common.links.backToDashboard
+    : TEXT.common.links.backToHome;
 
   const generateEventCode = (eventId: string): string => {
     return Math.abs(
@@ -41,7 +44,7 @@ const JoinEvent = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!eventCode.trim()) {
-      toast.error("Please enter an event code");
+      toast.error(TEXT.joinEvent.toast.missingCode);
       return;
     }
 
@@ -64,7 +67,7 @@ const JoinEvent = () => {
       );
 
       if (!matchingEvent) {
-        toast.error("Event not found. Please check the code and try again.");
+        toast.error(TEXT.joinEvent.toast.notFound);
         return;
       }
 
@@ -78,7 +81,7 @@ const JoinEvent = () => {
       navigate(`/event/${matchingEvent.slug}`);
     } catch (error) {
       console.error("Error finding event:", error);
-      toast.error("Failed to find event. Please try again.");
+      toast.error(TEXT.joinEvent.toast.failure);
     } finally {
       setIsLoading(false);
     }
@@ -101,9 +104,9 @@ const JoinEvent = () => {
           <div className="mx-auto w-16 h-16 bg-primary rounded-2xl flex items-center justify-center">
             <QrCode className="h-8 w-8 text-primary-foreground" />
           </div>
-          <CardTitle className="text-2xl">Join an Event</CardTitle>
+          <CardTitle className="text-2xl">{TEXT.joinEvent.header.title}</CardTitle>
           <CardDescription className="text-base">
-            Enter your numeric event code to check in
+            {TEXT.joinEvent.header.description}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -112,18 +115,17 @@ const JoinEvent = () => {
               <Alert className="mb-4">
                 <AlertCircle className="h-4 w-4" />
                 <AlertDescription>
-                  You are the host of this event. Visit your dashboard to see
-                  the event details.
+                  {TEXT.joinEvent.alert.organizer}
                 </AlertDescription>
               </Alert>
             )}
 
             <div className="space-y-2">
-              <Label htmlFor="eventCode">Event Code</Label>
+              <Label htmlFor="eventCode">{TEXT.joinEvent.form.label}</Label>
               <Input
                 id="eventCode"
                 type="text"
-                placeholder="Enter 6-digit code"
+                placeholder={TEXT.joinEvent.form.placeholder}
                 value={eventCode}
                 onChange={(e) => setEventCode(e.target.value)}
                 className="text-center text-lg tracking-wider"
@@ -139,7 +141,7 @@ const JoinEvent = () => {
                     type="button"
                     className="w-full h-12 text-base font-medium rounded-full"
                   >
-                    Go to Dashboard
+                    {TEXT.joinEvent.form.goToDashboard}
                   </Button>
                 </Link>
               ) : (
@@ -148,13 +150,15 @@ const JoinEvent = () => {
                   className="w-full h-12 text-base font-medium rounded-full"
                   disabled={isLoading}
                 >
-                  {isLoading ? "Finding Event..." : "Continue to Check-In"}
+                  {isLoading
+                    ? TEXT.joinEvent.form.submitLoading
+                    : TEXT.joinEvent.form.submitIdle}
                 </Button>
               )}
             </div>
 
             <p className="text-sm text-muted-foreground text-center">
-              You can also scan a QR code at the event entrance
+              {TEXT.joinEvent.form.helperText}
             </p>
           </form>
         </CardContent>

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -4,6 +4,7 @@ import { QrCode, LogOut } from "lucide-react";
 import { useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { User } from "@supabase/supabase-js";
+import { TEXT } from "@/constants/text";
 import HeroSection from "./landing/components/HeroSection";
 import FeaturesGrid from "./landing/components/FeaturesGrid";
 import HowItWorks from "./landing/components/HowItWorks";
@@ -41,14 +42,14 @@ const Landing = () => {
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <QrCode className="h-8 w-8 text-primary" />
-            <span className="text-2xl font-semibold">LinkBack</span>
+            <span className="text-2xl font-semibold">{TEXT.common.brand}</span>
           </div>
           <div className="flex items-center gap-3">
             {user ? (
               <>
                 <Link to="/dashboard">
                   <Button variant="ghost" className="rounded-full">
-                    My Events
+                    {TEXT.common.buttons.myEvents}
                   </Button>
                 </Link>
                 <Button
@@ -66,7 +67,7 @@ const Landing = () => {
                   variant="ghost"
                   className="rounded-full shadow-[0_0_20px_rgba(10,102,194,0.5)] hover:shadow-[0_0_30px_rgba(10,102,194,0.7)] text-[#0A66C2] hover:bg-[#0A66C2]/10 hover:text-[#0A66C2]"
                 >
-                  Sign in with LinkedIn
+                  {TEXT.common.buttons.signInWithLinkedIn}
                 </Button>
               </Link>
             )}
@@ -84,7 +85,7 @@ const Landing = () => {
       {/* Footer */}
       <footer className="border-t border-border py-8">
         <div className="container mx-auto px-4 text-center text-muted-foreground">
-          <p>© 2025 LinkBack. Powered by LinkedIn.</p>
+          <p>{TEXT.common.copy.footer}</p>
         </div>
       </footer>
     </div>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { TEXT } from "@/constants/text";
 
 const NotFound = () => {
   const location = useLocation();
@@ -14,10 +15,10 @@ const NotFound = () => {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>
+        <h1 className="mb-4 text-4xl font-bold">{TEXT.notFound.title}</h1>
+        <p className="mb-4 text-xl text-gray-600">{TEXT.notFound.subtitle}</p>
         <a href="/" className="text-blue-500 underline hover:text-blue-700">
-          Return to Home
+          {TEXT.notFound.link}
         </a>
       </div>
     </div>

--- a/src/pages/create-event/components/CreateEventForm.tsx
+++ b/src/pages/create-event/components/CreateEventForm.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { LocationAutocomplete } from "@/components/LocationAutocomplete";
+import { TEXT } from "@/constants/text";
 
 interface CreateEventFormProps {
   name: string;
@@ -38,19 +39,17 @@ const CreateEventForm = ({
 }: CreateEventFormProps) => (
   <Card className="shadow-xl">
     <CardHeader>
-      <CardTitle className="text-3xl">Create New Event</CardTitle>
-      <CardDescription>
-        Fill in the details below to generate your event QR code
-      </CardDescription>
+      <CardTitle className="text-3xl">{TEXT.createEvent.form.title}</CardTitle>
+      <CardDescription>{TEXT.createEvent.form.description}</CardDescription>
     </CardHeader>
     <CardContent>
       <form onSubmit={onSubmit} className="space-y-6">
         <div className="space-y-2">
-          <Label htmlFor="name">Event Name *</Label>
+          <Label htmlFor="name">{TEXT.createEvent.form.fields.nameLabel}</Label>
           <Input
             id="name"
             type="text"
-            placeholder="Summer Tech Meetup 2025"
+            placeholder={TEXT.createEvent.form.fields.namePlaceholder}
             value={name}
             onChange={(event) => onNameChange(event.target.value)}
             required
@@ -58,17 +57,17 @@ const CreateEventForm = ({
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="location">Location</Label>
+          <Label htmlFor="location">{TEXT.createEvent.form.fields.locationLabel}</Label>
           <LocationAutocomplete
             id="location"
             value={location}
             onChange={onLocationChange}
-            placeholder="TechHub Conference Center, San Francisco"
+            placeholder={TEXT.createEvent.form.fields.locationPlaceholder}
           />
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="starts_at">Start Date & Time</Label>
+          <Label htmlFor="starts_at">{TEXT.createEvent.form.fields.startsAtLabel}</Label>
           <Input
             id="starts_at"
             type="datetime-local"
@@ -78,11 +77,13 @@ const CreateEventForm = ({
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="linkedin_url">LinkedIn Event URL (optional)</Label>
+          <Label htmlFor="linkedin_url">
+            {TEXT.createEvent.form.fields.linkedinUrlLabel}
+          </Label>
           <Input
             id="linkedin_url"
             type="url"
-            placeholder="https://www.linkedin.com/events/..."
+            placeholder={TEXT.createEvent.form.fields.linkedinUrlPlaceholder}
             value={linkedinUrl}
             onChange={(event) => onLinkedinUrlChange(event.target.value)}
           />
@@ -93,7 +94,9 @@ const CreateEventForm = ({
           className="w-full rounded-full h-12 text-base font-medium"
           disabled={isSubmitting}
         >
-          {isSubmitting ? "Creating Event..." : "Create Event & Generate QR Code"}
+          {isSubmitting
+            ? TEXT.createEvent.form.submitLoading
+            : TEXT.createEvent.form.submitIdle}
         </Button>
       </form>
     </CardContent>

--- a/src/pages/create-event/components/CreateEventHeader.tsx
+++ b/src/pages/create-event/components/CreateEventHeader.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { QrCode, ArrowLeft } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
 interface CreateEventHeaderProps {
   backPath: string;
@@ -11,12 +12,12 @@ const CreateEventHeader = ({ backPath, backText }: CreateEventHeaderProps) => (
   <>
     <header className="border-b border-border bg-background/80 backdrop-blur-sm">
       <div className="container mx-auto px-4 py-4 flex items-center justify-between">
-        <Link to="/dashboard" className="flex items-center gap-2">
-          <QrCode className="h-8 w-8 text-primary" />
-          <span className="text-2xl font-semibold">LinkBack</span>
-        </Link>
-      </div>
-    </header>
+          <Link to="/dashboard" className="flex items-center gap-2">
+            <QrCode className="h-8 w-8 text-primary" />
+            <span className="text-2xl font-semibold">{TEXT.common.brand}</span>
+          </Link>
+        </div>
+      </header>
 
     <div className="container mx-auto px-4 pt-8">
       <div className="max-w-2xl mx-auto">

--- a/src/pages/dashboard/components/DashboardHeader.tsx
+++ b/src/pages/dashboard/components/DashboardHeader.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { QrCode, LogOut } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
 interface DashboardHeaderProps {
   name?: string | null;
@@ -17,13 +18,17 @@ const DashboardHeader = ({ name, headline, avatarUrl, onSignOut }: DashboardHead
     .join("")
     .toUpperCase();
 
+  const welcomeMessage = name
+    ? `${TEXT.dashboard.header.welcomePrefix} ${name}!`
+    : TEXT.dashboard.header.welcomePrefix;
+
   return (
     <>
       <header className="border-b border-border bg-background/80 backdrop-blur-sm sticky top-0 z-50">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
           <Link to="/" className="flex items-center gap-2">
             <QrCode className="h-8 w-8 text-primary" />
-            <span className="text-2xl font-semibold">LinkBack</span>
+            <span className="text-2xl font-semibold">{TEXT.common.brand}</span>
           </Link>
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-3">
@@ -51,9 +56,9 @@ const DashboardHeader = ({ name, headline, avatarUrl, onSignOut }: DashboardHead
 
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-6xl mx-auto">
-          <h1 className="text-4xl font-bold mb-2">Welcome back, {name}!</h1>
+          <h1 className="text-4xl font-bold mb-2">{welcomeMessage}</h1>
           <p className="text-muted-foreground">
-            Host events, check in to events, and connect with attendees.
+            {TEXT.dashboard.header.tagline}
           </p>
         </div>
       </div>

--- a/src/pages/dashboard/components/MyEventsList.tsx
+++ b/src/pages/dashboard/components/MyEventsList.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Calendar, Users } from "lucide-react";
+import { TEXT } from "@/constants/text";
 import EmptyState from "./EmptyState";
 
 interface MinimalEvent {
@@ -19,7 +20,7 @@ interface MyEventsListProps {
 const MyEventsList = ({ events, isLoading }: MyEventsListProps) => {
   return (
     <section>
-      <h2 className="text-2xl font-semibold mb-4">Your Events</h2>
+      <h2 className="text-2xl font-semibold mb-4">{TEXT.dashboard.myEvents.title}</h2>
 
       {isLoading ? (
         <Card>
@@ -27,21 +28,23 @@ const MyEventsList = ({ events, isLoading }: MyEventsListProps) => {
             <div className="flex justify-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary" />
             </div>
-            <p className="text-muted-foreground">Loading your events...</p>
-          </CardContent>
-        </Card>
-      ) : events.length === 0 ? (
-        <EmptyState
-          icon={<Calendar className="h-12 w-12 text-muted-foreground" />}
-          title="Ready to host your first event?"
-          description="Create your QR in under 10 seconds."
-          actions={
-            <Link to="/create-event" state={{ fromDashboard: true }}>
-              <Button className="rounded-full">Create Your First Event</Button>
-            </Link>
-          }
-        />
-      ) : (
+            <p className="text-muted-foreground">{TEXT.dashboard.myEvents.loading}</p>
+      </CardContent>
+    </Card>
+  ) : events.length === 0 ? (
+    <EmptyState
+      icon={<Calendar className="h-12 w-12 text-muted-foreground" />}
+      title={TEXT.dashboard.myEvents.emptyTitle}
+      description={TEXT.dashboard.myEvents.emptyDescription}
+      actions={
+        <Link to="/create-event" state={{ fromDashboard: true }}>
+          <Button className="rounded-full">
+            {TEXT.common.buttons.createFirstEvent}
+          </Button>
+        </Link>
+      }
+    />
+  ) : (
         <div className="grid md:grid-cols-2 gap-4">
           {events.map((event) => (
             <Link key={event.id} to={`/event/${event.slug}`}>
@@ -51,13 +54,13 @@ const MyEventsList = ({ events, isLoading }: MyEventsListProps) => {
                   <CardDescription>
                     {event.starts_at
                       ? new Date(event.starts_at).toLocaleDateString()
-                      : "Date not set"}
+                      : TEXT.common.labels.dateNotSet}
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
                   <div className="flex items-center gap-2 text-sm text-primary">
                     <Users className="h-4 w-4" />
-                    <span>View attendees →</span>
+                    <span>{TEXT.dashboard.myEvents.viewAttendees}</span>
                   </div>
                 </CardContent>
               </Card>

--- a/src/pages/dashboard/components/UpcomingSection.tsx
+++ b/src/pages/dashboard/components/UpcomingSection.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Camera, QrCode, Users } from "lucide-react";
+import { TEXT } from "@/constants/text";
 import EmptyState from "./EmptyState";
 
 interface MinimalEvent {
@@ -19,7 +20,7 @@ interface UpcomingSectionProps {
 
 const UpcomingSection = ({ events, isLoading, onScan }: UpcomingSectionProps) => (
   <section>
-    <h2 className="text-2xl font-semibold mb-4">Events You've Attended</h2>
+    <h2 className="text-2xl font-semibold mb-4">{TEXT.dashboard.upcoming.title}</h2>
 
     {isLoading ? (
       <Card>
@@ -27,23 +28,23 @@ const UpcomingSection = ({ events, isLoading, onScan }: UpcomingSectionProps) =>
           <div className="flex justify-center">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary" />
           </div>
-          <p className="text-muted-foreground">Loading your upcoming events...</p>
+          <p className="text-muted-foreground">{TEXT.dashboard.upcoming.loading}</p>
         </CardContent>
       </Card>
     ) : events.length === 0 ? (
       <EmptyState
         icon={<QrCode className="h-12 w-12 text-muted-foreground" />}
-        title="No check-ins yet."
-        description="Scan a QR or enter a 6-digit code to get started."
+        title={TEXT.dashboard.upcoming.emptyTitle}
+        description={TEXT.dashboard.upcoming.emptyDescription}
         actions={
           <>
             <Button onClick={onScan} className="rounded-full">
               <Camera className="h-4 w-4 mr-2" />
-              Scan QR Code
+              {TEXT.common.buttons.scanQrCode}
             </Button>
             <Link to="/join-event" state={{ fromDashboard: true }}>
               <Button variant="outline" className="rounded-full">
-                Join by Code
+                {TEXT.common.buttons.joinByCode}
               </Button>
             </Link>
           </>
@@ -59,13 +60,13 @@ const UpcomingSection = ({ events, isLoading, onScan }: UpcomingSectionProps) =>
                 <CardDescription>
                   {event.starts_at
                     ? new Date(event.starts_at).toLocaleDateString()
-                    : "Date not set"}
+                    : TEXT.common.labels.dateNotSet}
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="flex items-center gap-2 text-sm text-primary">
                   <Users className="h-4 w-4" />
-                  <span>View attendee list →</span>
+                  <span>{TEXT.dashboard.upcoming.viewAttendeeList}</span>
                 </div>
               </CardContent>
             </Card>

--- a/src/pages/demo/components/DemoHeader.tsx
+++ b/src/pages/demo/components/DemoHeader.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { QrCode } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
 const DemoHeader = () => (
   <>
@@ -8,11 +9,11 @@ const DemoHeader = () => (
       <div className="container mx-auto px-4 py-4 flex items-center justify-between">
         <Link to="/" className="flex items-center gap-2">
           <QrCode className="h-8 w-8 text-primary" />
-          <span className="text-2xl font-semibold">LinkBack</span>
+          <span className="text-2xl font-semibold">{TEXT.common.brand}</span>
         </Link>
         <Link to="/auth">
           <Button variant="outline" className="rounded-full">
-            Get Started
+            {TEXT.common.buttons.getStarted}
           </Button>
         </Link>
       </div>
@@ -20,9 +21,9 @@ const DemoHeader = () => (
 
     <div className="container mx-auto px-4 pt-12">
       <div className="max-w-4xl mx-auto text-center space-y-4">
-        <h1 className="text-4xl md:text-5xl font-bold">See LinkBack in Action</h1>
+        <h1 className="text-4xl md:text-5xl font-bold">{TEXT.demo.header.title}</h1>
         <p className="text-xl text-muted-foreground">
-          Experience how easy event check-ins can be
+          {TEXT.demo.header.subtitle}
         </p>
       </div>
     </div>

--- a/src/pages/demo/components/DemoNotes.tsx
+++ b/src/pages/demo/components/DemoNotes.tsx
@@ -1,17 +1,18 @@
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
 const DemoNotes = () => (
   <div className="text-center pt-8">
     <Link to="/auth">
       <Button size="lg" className="rounded-full px-8 h-12 text-base font-medium">
-        Try LinkBack Now
+        {TEXT.common.buttons.tryLinkBackNow}
         <ArrowRight className="ml-2 h-5 w-5" />
       </Button>
     </Link>
     <p className="text-sm text-muted-foreground mt-4">
-      No payments. No friction. Simply login and start scanning.
+      {TEXT.demo.notes.helper}
     </p>
   </div>
 );

--- a/src/pages/demo/components/DemoShowcase.tsx
+++ b/src/pages/demo/components/DemoShowcase.tsx
@@ -6,160 +6,134 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { QrCode, Check } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
-const DemoShowcase = () => (
-  <div className="space-y-8">
-    <Card>
-      <CardHeader>
-        <div className="flex items-start gap-4">
-          <div className="w-12 h-12 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold flex-shrink-0">
-            1
-          </div>
-          <div className="flex-1">
-            <CardTitle className="text-2xl mb-2">
-              Organizer Creates Event
-            </CardTitle>
-            <CardDescription className="text-base">
-              Sign up as an organizer, create your event with a name and optional
-              details
-            </CardDescription>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="pl-20">
-        <div className="bg-muted p-6 rounded-xl space-y-3">
-          <div className="flex items-center gap-2">
-            <Check className="h-5 w-5 text-success" />
-            <span>Enter event name: "Tech Meetup 2025"</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Check className="h-5 w-5 text-success" />
-            <span>Set date and time (optional)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Check className="h-5 w-5 text-success" />
-            <span>Add LinkedIn event URL (optional)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Check className="h-5 w-5 text-success" />
-            <span>Get unique QR code instantly</span>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+const DemoShowcase = () => {
+  const [stepOne, stepTwo, stepThree, stepFour] = TEXT.demo.showcase.steps;
 
-    <Card>
-      <CardHeader>
-        <div className="flex items-start gap-4">
-          <div className="w-12 h-12 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold flex-shrink-0">
-            2
-          </div>
-          <div className="flex-1">
-            <CardTitle className="text-2xl mb-2">Display QR Code</CardTitle>
-            <CardDescription className="text-base">
-              Print the QR code or display it digitally at your event entrance
-            </CardDescription>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="pl-20">
-        <div className="bg-muted p-6 rounded-xl">
-          <div className="flex items-center justify-center">
-            <div className="bg-white p-6 rounded-xl inline-block shadow-md">
-              <QrCode className="h-32 w-32 text-primary" />
+  return (
+    <div className="space-y-8">
+      <Card>
+        <CardHeader>
+          <div className="flex items-start gap-4">
+            <div className="w-12 h-12 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold flex-shrink-0">
+              1
+            </div>
+            <div className="flex-1">
+              <CardTitle className="text-2xl mb-2">{stepOne.title}</CardTitle>
+              <CardDescription className="text-base">
+                {stepOne.description}
+              </CardDescription>
             </div>
           </div>
-          <p className="text-center text-sm text-muted-foreground mt-4">
-            Each event gets a unique QR code
-          </p>
-        </div>
-      </CardContent>
-    </Card>
-
-    <Card>
-      <CardHeader>
-        <div className="flex items-start gap-4">
-          <div className="w-12 h-12 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold flex-shrink-0">
-            3
-          </div>
-          <div className="flex-1">
-            <CardTitle className="text-2xl mb-2">Attendees Check In</CardTitle>
-            <CardDescription className="text-base">
-              Guests scan the QR code with their phone and authenticate with
-              LinkedIn
-            </CardDescription>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="pl-20">
-        <div className="bg-muted p-6 rounded-xl space-y-4">
-          <div className="space-y-2">
-            <p className="font-medium">⚠️ Privacy Notice Shown:</p>
-            <div className="bg-background/80 p-4 rounded-lg border border-border">
-              <p className="text-sm">
-                "Your LinkedIn name and headline will be shown to other
-                attendees of this event."
-              </p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2 text-success">
-            <Check className="h-5 w-5" />
-            <span className="font-medium">Attendance recorded automatically</span>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-
-    <Card>
-      <CardHeader>
-        <div className="flex items-start gap-4">
-          <div className="w-12 h-12 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold flex-shrink-0">
-            4
-          </div>
-          <div className="flex-1">
-            <CardTitle className="text-2xl mb-2">View Attendee List</CardTitle>
-            <CardDescription className="text-base">
-              Organizers and attendees can see the verified list of who's at the
-              event
-            </CardDescription>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="pl-20">
-        <div className="bg-muted p-6 rounded-xl">
-          <div className="space-y-3">
-            {[
-              {
-                name: "Sarah Johnson",
-                title: "Senior Product Manager at Tech Corp",
-              },
-              {
-                name: "Michael Chen",
-                title: "Software Engineer at StartupXYZ",
-              },
-              {
-                name: "Emma Davis",
-                title: "UX Designer at Creative Studio",
-              },
-            ].map((person, idx) => (
-              <div
-                key={idx}
-                className="flex items-center gap-3 bg-background p-4 rounded-lg border border-border"
-              >
-                <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center font-semibold text-primary">
-                  {person.name.substring(0, 2)}
-                </div>
-                <div className="flex-1">
-                  <p className="font-semibold">{person.name}</p>
-                  <p className="text-sm text-muted-foreground">{person.title}</p>
-                </div>
+        </CardHeader>
+        <CardContent className="pl-20">
+          <div className="bg-muted p-6 rounded-xl space-y-3">
+            {stepOne.checklist.map((item) => (
+              <div key={item} className="flex items-center gap-2">
+                <Check className="h-5 w-5 text-success" />
+                <span>{item}</span>
               </div>
             ))}
           </div>
-        </div>
-      </CardContent>
-    </Card>
-  </div>
-);
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-start gap-4">
+            <div className="w-12 h-12 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold flex-shrink-0">
+              2
+            </div>
+            <div className="flex-1">
+              <CardTitle className="text-2xl mb-2">{stepTwo.title}</CardTitle>
+              <CardDescription className="text-base">
+                {stepTwo.description}
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="pl-20">
+          <div className="bg-muted p-6 rounded-xl">
+            <div className="flex items-center justify-center">
+              <div className="bg-white p-6 rounded-xl inline-block shadow-md">
+                <QrCode className="h-32 w-32 text-primary" />
+              </div>
+            </div>
+            <p className="text-center text-sm text-muted-foreground mt-4">
+              {stepTwo.note}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-start gap-4">
+            <div className="w-12 h-12 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold flex-shrink-0">
+              3
+            </div>
+            <div className="flex-1">
+              <CardTitle className="text-2xl mb-2">{stepThree.title}</CardTitle>
+              <CardDescription className="text-base">
+                {stepThree.description}
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="pl-20">
+          <div className="bg-muted p-6 rounded-xl space-y-4">
+            <div className="space-y-2">
+              <p className="font-medium">{stepThree.privacyNotice}</p>
+              <div className="bg-background/80 p-4 rounded-lg border border-border">
+                <p className="text-sm">{stepThree.privacyCopy}</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 text-success">
+              <Check className="h-5 w-5" />
+              <span className="font-medium">{stepThree.confirmation}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-start gap-4">
+            <div className="w-12 h-12 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold flex-shrink-0">
+              4
+            </div>
+            <div className="flex-1">
+              <CardTitle className="text-2xl mb-2">{stepFour.title}</CardTitle>
+              <CardDescription className="text-base">
+                {stepFour.description}
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="pl-20">
+          <div className="bg-muted p-6 rounded-xl">
+            <div className="space-y-3">
+              {stepFour.attendees.map((person) => (
+                <div
+                  key={person.name}
+                  className="flex items-center gap-3 bg-background p-4 rounded-lg border border-border"
+                >
+                  <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center font-semibold text-primary">
+                    {person.name.substring(0, 2)}
+                  </div>
+                  <div className="flex-1">
+                    <p className="font-semibold">{person.name}</p>
+                    <p className="text-sm text-muted-foreground">{person.title}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
 
 export default DemoShowcase;

--- a/src/pages/event/components/AttendButton.tsx
+++ b/src/pages/event/components/AttendButton.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Linkedin } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { TEXT } from "@/constants/text";
 
 interface AttendButtonProps {
   currentUserId: string | null;
@@ -34,13 +35,14 @@ const AttendButton = ({
     className,
   );
 
-  const buttonLabel = mode === "linkedin"
-    ? isLoading
-      ? "Checking In..."
-      : "Check In with LinkedIn"
-    : isLoading
-    ? "Checking In..."
-    : "Check In to This Event";
+  const buttonLabel =
+    mode === "linkedin"
+      ? isLoading
+        ? TEXT.event.attendButton.checkingIn
+        : TEXT.event.attendButton.checkInLinkedIn
+      : isLoading
+      ? TEXT.event.attendButton.checkingIn
+      : TEXT.event.attendButton.checkIn;
 
   const button = (
     <Button

--- a/src/pages/event/components/AttendeeList.tsx
+++ b/src/pages/event/components/AttendeeList.tsx
@@ -3,6 +3,8 @@ import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Linkedin, Users } from "lucide-react";
 import type { ProfileRow } from "@/hooks/useSupabaseData";
+import { TEXT } from "@/constants/text";
+import { toast } from "sonner";
 
 interface AttendeeListProps {
   attendees: ProfileRow[];
@@ -25,20 +27,23 @@ const AttendeeList = ({
         <div className="flex items-center gap-2">
           <Users className="h-5 w-5 text-muted-foreground" />
           <span className="text-lg font-medium">
-            {attendeeCount} {attendeeCount === 1 ? "Attendee" : "Attendees"}
+            {attendeeCount}{" "}
+            {attendeeCount === 1
+              ? TEXT.event.attendeeList.singular
+              : TEXT.event.attendeeList.plural}
           </span>
         </div>
       </CardHeader>
       <CardContent>
         {isLoading ? (
           <p className="text-center text-muted-foreground py-8">
-            Loading attendees...
+            {TEXT.event.attendeeList.loading}
           </p>
         ) : attendeeCount === 0 ? (
           <p className="text-center text-muted-foreground py-8">
             {isOrganizer
-              ? "No attendees yet. Share your QR code to get people to check in!"
-              : "No attendees yet. Be the first to check in!"}
+              ? TEXT.event.attendeeList.organizerEmpty
+              : TEXT.event.attendeeList.attendeeEmpty}
           </p>
         ) : (
           <div className="space-y-3">
@@ -76,13 +81,15 @@ const AttendeeList = ({
                           `https://www.linkedin.com/in/${attendee.linkedin_id}`,
                           "_blank",
                         );
+                      } else {
+                        toast.info(TEXT.event.header.linkedInMissing);
                       }
                     }}
                   >
                     <Linkedin className="h-4 w-4" />
                     {currentUserId === attendee.id
-                      ? "View Your Profile"
-                      : "View Profile"}
+                      ? TEXT.event.header.viewSelfProfile
+                      : TEXT.event.header.viewProfile}
                   </Button>
                 </div>
               );

--- a/src/pages/event/components/EventHeader.tsx
+++ b/src/pages/event/components/EventHeader.tsx
@@ -4,6 +4,8 @@ import { CardTitle } from "@/components/ui/card";
 import { Calendar, CheckCircle2, Linkedin, MapPin, QrCode, Users } from "lucide-react";
 import { useMemo } from "react";
 import type { EventRow, ProfileRow } from "@/hooks/useSupabaseData";
+import { TEXT } from "@/constants/text";
+import { toast } from "sonner";
 
 interface EventHeaderProps {
   event: EventRow;
@@ -42,13 +44,13 @@ const EventHeader = ({
     return (
       <div className="text-center space-y-6">
         <div className="space-y-2">
-          <h1 className="text-3xl font-bold mb-4">{event.name}</h1>
-          <div className="space-y-2 text-muted-foreground">
-            {eventCode && (
-              <div className="text-sm text-primary font-medium">
-                Event Code: {eventCode}
-              </div>
-            )}
+              <h1 className="text-3xl font-bold mb-4">{event.name}</h1>
+              <div className="space-y-2 text-muted-foreground">
+                {eventCode && (
+                  <div className="text-sm text-primary font-medium">
+                    {TEXT.common.labels.eventCode}: {eventCode}
+                  </div>
+                )}
             {event.starts_at && (
               <div className="flex items-center justify-center gap-2">
                 <Calendar className="h-4 w-4" />
@@ -70,7 +72,9 @@ const EventHeader = ({
             {organizer && (
               <div className="flex items-center justify-center gap-2">
                 <Users className="h-4 w-4" />
-                <span>Hosted by {organizer.name}</span>
+                <span>
+                  {TEXT.event.header.hostedBy} {organizer.name}
+                </span>
               </div>
             )}
           </div>
@@ -83,15 +87,15 @@ const EventHeader = ({
     <div className="space-y-4">
       <div>
         <CardTitle className="text-4xl mb-2">{event.name}</CardTitle>
-        <div className="flex flex-col gap-2 text-muted-foreground">
-          {eventCode && (
-            <div className="flex items-center gap-2">
-              <QrCode className="h-4 w-4" />
-              <span className="font-mono font-semibold text-foreground">
-                Event Code: {eventCode}
-              </span>
-            </div>
-          )}
+            <div className="flex flex-col gap-2 text-muted-foreground">
+              {eventCode && (
+                <div className="flex items-center gap-2">
+                  <QrCode className="h-4 w-4" />
+                  <span className="font-mono font-semibold text-foreground">
+                    {TEXT.common.labels.eventCode}: {eventCode}
+                  </span>
+                </div>
+              )}
           {event.starts_at && (
             <div className="flex items-center gap-2">
               <Calendar className="h-4 w-4" />
@@ -110,21 +114,23 @@ const EventHeader = ({
               <span>{event.location}</span>
             </div>
           )}
-          {organizer && (
-            <div className="flex items-center gap-4 mt-4 pt-4 border-t border-border">
-              <Avatar className="h-12 w-12">
-                <AvatarImage src={organizer.avatar_url ?? undefined} />
-                <AvatarFallback className="bg-primary text-primary-foreground">
+              {organizer && (
+                <div className="flex items-center gap-4 mt-4 pt-4 border-t border-border">
+                  <Avatar className="h-12 w-12">
+                    <AvatarImage src={organizer.avatar_url ?? undefined} />
+                    <AvatarFallback className="bg-primary text-primary-foreground">
                   {hostInitials}
                 </AvatarFallback>
               </Avatar>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm text-muted-foreground mb-0.5">Hosted by</p>
-                <p className="font-semibold text-foreground">{organizer.name}</p>
-                {organizer.headline && (
-                  <p className="text-sm text-muted-foreground truncate">
-                    {organizer.headline}
-                  </p>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-muted-foreground mb-0.5">
+                      {TEXT.event.header.hostedBy}
+                    </p>
+                    <p className="font-semibold text-foreground">{organizer.name}</p>
+                    {organizer.headline && (
+                      <p className="text-sm text-muted-foreground truncate">
+                        {organizer.headline}
+                      </p>
                 )}
               </div>
               <Button
@@ -135,13 +141,15 @@ const EventHeader = ({
                       `https://www.linkedin.com/in/${organizer.linkedin_id}`,
                       "_blank",
                     );
+                  } else {
+                    toast.info(TEXT.event.header.linkedInMissing);
                   }
                 }}
               >
                 <Linkedin className="h-4 w-4" />
                 {currentUserId === organizer.id
-                  ? "View Your Profile"
-                  : "View Profile"}
+                  ? TEXT.event.header.viewSelfProfile
+                  : TEXT.event.header.viewProfile}
               </Button>
             </div>
           )}
@@ -156,14 +164,14 @@ const EventHeader = ({
           className="w-full rounded-full h-12 text-base font-medium"
         >
           <QrCode className="h-5 w-5 mr-2" />
-          View QR Code
+          {TEXT.common.buttons.viewQrCode}
         </Button>
       )}
 
       {isAttending && (
         <div className="flex items-center gap-2 text-success bg-success/10 px-4 py-2 rounded-full w-fit">
           <CheckCircle2 className="h-5 w-5" />
-          <span className="font-medium">You're checked in!</span>
+          <span className="font-medium">{TEXT.event.header.checkedIn}</span>
         </div>
       )}
     </div>

--- a/src/pages/landing/components/FeaturesGrid.tsx
+++ b/src/pages/landing/components/FeaturesGrid.tsx
@@ -1,4 +1,5 @@
 import { QrCode, Shield, Users } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
 const FeaturesGrid = () => (
   <section className="py-20">
@@ -7,10 +8,11 @@ const FeaturesGrid = () => (
         <div className="w-12 h-12 rounded-xl bg-accent flex items-center justify-center mb-4">
           <QrCode className="h-6 w-6 text-accent-foreground" />
         </div>
-        <h3 className="text-xl font-semibold mb-2">One QR Code</h3>
+        <h3 className="text-xl font-semibold mb-2">
+          {TEXT.landing.features.oneQrCode.title}
+        </h3>
         <p className="text-muted-foreground">
-          Generate a unique QR code for each event. Display it at your venue or
-          share the link.
+          {TEXT.landing.features.oneQrCode.description}
         </p>
       </div>
 
@@ -18,10 +20,11 @@ const FeaturesGrid = () => (
         <div className="w-12 h-12 rounded-xl bg-accent flex items-center justify-center mb-4">
           <Shield className="h-6 w-6 text-accent-foreground" />
         </div>
-        <h3 className="text-xl font-semibold mb-2">LinkedIn Verified</h3>
+        <h3 className="text-xl font-semibold mb-2">
+          {TEXT.landing.features.linkedinVerified.title}
+        </h3>
         <p className="text-muted-foreground">
-          Authentic attendee data from LinkedIn. No fake accounts, just real
-          professionals.
+          {TEXT.landing.features.linkedinVerified.description}
         </p>
       </div>
 
@@ -29,10 +32,11 @@ const FeaturesGrid = () => (
         <div className="w-12 h-12 rounded-xl bg-accent flex items-center justify-center mb-4">
           <Users className="h-6 w-6 text-accent-foreground" />
         </div>
-        <h3 className="text-xl font-semibold mb-2">Instant Lists</h3>
+        <h3 className="text-xl font-semibold mb-2">
+          {TEXT.landing.features.instantLists.title}
+        </h3>
         <p className="text-muted-foreground">
-          View who attended in real-time. Names, headlines, and profile links at
-          your fingertips.
+          {TEXT.landing.features.instantLists.description}
         </p>
       </div>
     </div>

--- a/src/pages/landing/components/FooterCTA.tsx
+++ b/src/pages/landing/components/FooterCTA.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Linkedin } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
 const FooterCTA = () => (
   <section className="py-20 pb-32">
@@ -8,10 +9,10 @@ const FooterCTA = () => (
       <div className="absolute inset-0 bg-gradient-to-br from-white/5 to-transparent pointer-events-none" />
       <div className="relative z-10">
         <h2 className="text-3xl md:text-4xl font-bold text-primary-foreground mb-4">
-          Ready to streamline your events?
+          {TEXT.landing.footerCta.title}
         </h2>
         <p className="text-xl text-primary-foreground/90 mb-8">
-          Join LinkBack today and start building verified attendee lists.
+          {TEXT.landing.footerCta.description}
         </p>
         <Link to="/auth">
           <Button
@@ -19,7 +20,7 @@ const FooterCTA = () => (
             className="rounded-full px-8 h-12 text-base font-medium shadow-lg hover:scale-105 transition-transform bg-[#0A66C2] hover:bg-[#004182] text-white"
           >
             <Linkedin className="h-5 w-5 mr-2" />
-            Sign in with LinkedIn
+            {TEXT.common.buttons.signInWithLinkedIn}
           </Button>
         </Link>
       </div>

--- a/src/pages/landing/components/HeroSection.tsx
+++ b/src/pages/landing/components/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { QrCode, Calendar, Linkedin } from "lucide-react";
+import { TEXT } from "@/constants/text";
 
 interface HeroSectionProps {
   isAuthenticated: boolean;
@@ -10,7 +11,7 @@ const HeroSection = ({ isAuthenticated }: HeroSectionProps) => (
   <section className="py-20 md:py-32 text-center">
     <div className="max-w-3xl mx-auto space-y-8">
       <h1 className="text-5xl md:text-6xl font-bold tracking-tight">
-        Event Check-In,
+        {TEXT.landing.hero.titleLine}
         <br />
         <span
           className="text-primary inline-block animate-fade-in [animation-delay:0.3s] [animation-fill-mode:both] bg-gradient-to-r from-primary via-primary to-primary bg-[length:200%_100%] animate-[shimmer_3s_ease-in-out_infinite] bg-clip-text"
@@ -19,13 +20,13 @@ const HeroSection = ({ isAuthenticated }: HeroSectionProps) => (
               "0 0 30px rgba(255, 150, 200, 0.9), 0 0 60px rgba(255, 150, 200, 0.7), 0 0 90px rgba(255, 150, 200, 0.5)",
           }}
         >
-          Simplified.
+          {TEXT.landing.hero.highlight}
         </span>
       </h1>
       <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
         {isAuthenticated
-          ? "Streamline your event networking with LinkedIn integration. Check in instantly, connect with attendees, and build your professional network effortlessly."
-          : "Create a QR code for your event. Attendees scan to check in with LinkedIn. Build verified attendee lists instantly."}
+          ? TEXT.landing.hero.authenticatedDescription
+          : TEXT.landing.hero.guestDescription}
       </p>
       <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4">
         {isAuthenticated ? (
@@ -36,7 +37,7 @@ const HeroSection = ({ isAuthenticated }: HeroSectionProps) => (
                 className="rounded-full px-8 h-12 text-base font-medium transition-all hover:shadow-lg"
               >
                 <QrCode className="h-5 w-5 mr-2" />
-                Join an Event
+                {TEXT.landing.hero.joinButton}
               </Button>
             </Link>
             <Link to="/create-event">
@@ -46,7 +47,7 @@ const HeroSection = ({ isAuthenticated }: HeroSectionProps) => (
                 className="rounded-full px-8 h-12 text-base font-medium"
               >
                 <Calendar className="h-5 w-5 mr-2" />
-                Host an Event
+                {TEXT.landing.hero.hostButton}
               </Button>
             </Link>
           </>
@@ -58,7 +59,7 @@ const HeroSection = ({ isAuthenticated }: HeroSectionProps) => (
                 className="rounded-full px-8 h-12 text-base font-medium transition-all hover:shadow-lg bg-[#0A66C2] hover:bg-[#004182] text-white shadow-[0_0_20px_rgba(10,102,194,0.5)] hover:shadow-[0_0_30px_rgba(10,102,194,0.7)]"
               >
                 <Linkedin className="h-5 w-5 mr-2" />
-                Sign in with LinkedIn
+                {TEXT.landing.hero.signInButton}
               </Button>
             </Link>
             <Link to="/demo">
@@ -67,7 +68,7 @@ const HeroSection = ({ isAuthenticated }: HeroSectionProps) => (
                 variant="outline"
                 className="rounded-full px-8 h-12 text-base font-medium"
               >
-                How It Works
+                {TEXT.landing.hero.demoButton}
               </Button>
             </Link>
           </>

--- a/src/pages/landing/components/HowItWorks.tsx
+++ b/src/pages/landing/components/HowItWorks.tsx
@@ -1,30 +1,13 @@
+import { TEXT } from "@/constants/text";
+
 const HowItWorks = () => (
   <section className="py-20">
     <div className="max-w-4xl mx-auto">
       <h2 className="text-3xl md:text-4xl font-bold text-center mb-16">
-        How It Works
+        {TEXT.landing.howItWorks.title}
       </h2>
       <div className="space-y-12">
-        {[
-          {
-            step: "1",
-            title: "Create Your Event",
-            description:
-              "Sign up as an organizer and create your event in seconds. Get a unique QR code instantly.",
-          },
-          {
-            step: "2",
-            title: "Attendees Check In",
-            description:
-              "Guests scan the QR code and authenticate with LinkedIn. Their attendance is recorded automatically.",
-          },
-          {
-            step: "3",
-            title: "View Attendee List",
-            description:
-              "Access the complete list of verified attendees with their LinkedIn profiles, names, and headlines.",
-          },
-        ].map(({ step, title, description }, index) => (
+        {TEXT.landing.howItWorks.steps.map(({ step, title, description }, index) => (
           <div
             key={step}
             className="flex flex-col md:flex-row gap-6 items-center animate-fade-in"


### PR DESCRIPTION
## Pull Request: Centralize Website Copy

### Overview

This PR moves all the hardcoded UI text from components into a single constants file. Makes it easier to update copy without hunting through component files, and sets things up if we ever need to add translations later.

**Note:** These changes were generated using ChatGPT Codex and have been reviewed for consistency and correctness.

---

### What Changed

**Text Constants**

Created `src/constants/text.ts` with organized sections for:

- Landing page (hero, features, call-to-action)
- Dashboard (headers, empty states)
- Event pages (buttons, attendee labels)
- Auth page (headings, prompts)
- Demo and create event pages (static labels)

**Component Updates**

Replaced hardcoded strings in components with references to the new constants. Kept all the existing structure and styling the same.

---

### Impact

Copy changes now happen in one place instead of scattered across multiple files. Ensures consistent wording when the same text appears in different spots. If we ever need to support multiple languages, the structure is already in place to swap out the constants file.

---

### Notes

Only pulled out static, user-facing text. Dynamic stuff like user names and event data stays inline where it belongs. The file structure follows the page structure to keep things easy to find.