### PR TITLE
[feature/LIN-21] Update Join Event CTA

### DIFF
--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -16,6 +16,7 @@ export const TEXT = {
       joinByCode: "Join by Code",
       joinFirstEvent: "Join your first event",
       goToDashboard: "Go to Dashboard",
+      goToEvent: "Go to Event",
       continueCheckIn: "Continue to Check-In",
       findingEvent: "Finding Event...",
       createEventAndQr: "Create Event & Generate QR Code",
@@ -225,12 +226,12 @@ export const TEXT = {
       description: "Enter your numeric event code to check in",
     },
     alert: {
-      organizer: "You are the host of this event. Visit your dashboard to see the event details.",
+      organizer: "You are the host of this event. Open your event to manage check-ins.",
     },
     form: {
       label: "Event Code",
       placeholder: "Enter 6-digit code",
-      goToDashboard: "Go to Dashboard",
+      goToEvent: "Go to Event",
       submitIdle: "Continue to Check-In",
       submitLoading: "Finding Event...",
       helperText: "You can also scan a QR code at the event entrance",

--- a/src/pages/JoinEvent.tsx
+++ b/src/pages/JoinEvent.tsx
@@ -22,6 +22,7 @@ const JoinEvent = () => {
   const [eventCode, setEventCode] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isOwnEvent, setIsOwnEvent] = useState(false);
+  const [ownEventSlug, setOwnEventSlug] = useState<string | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
@@ -50,6 +51,7 @@ const JoinEvent = () => {
 
     setIsLoading(true);
     setIsOwnEvent(false);
+    setOwnEventSlug(null);
 
     try {
       // Get current user
@@ -74,6 +76,7 @@ const JoinEvent = () => {
       // Check if user is the organizer
       if (userId && matchingEvent.organizer_id === userId) {
         setIsOwnEvent(true);
+        setOwnEventSlug(matchingEvent.slug);
         return;
       }
 
@@ -135,13 +138,13 @@ const JoinEvent = () => {
             </div>
 
             <div className="pt-2">
-              {isOwnEvent ? (
-                <Link to="/dashboard">
+              {isOwnEvent && ownEventSlug ? (
+                <Link to={`/event/${ownEventSlug}`}>
                   <Button
                     type="button"
                     className="w-full h-12 text-base font-medium rounded-full"
                   >
-                    {TEXT.joinEvent.form.goToDashboard}
+                    {TEXT.joinEvent.form.goToEvent}
                   </Button>
                 </Link>
               ) : (


### PR DESCRIPTION
Changed the organizer fallback button to say 'Go to Event' and route directly to the event page. Added a state to capture the matching slug and refreshed the text constant to reflect the new wording.