### PR TITLE
[chore] Preserve event redirect through LinkedIn auth flow

### DIFF
--- a/src/__tests__/smoke/AttendButton.test.tsx
+++ b/src/__tests__/smoke/AttendButton.test.tsx
@@ -37,4 +37,24 @@ describe('AttendButton smoke', () => {
 
     expect(screen.queryByRole('button', { name: /check in/i })).not.toBeInTheDocument();
   });
+
+  it('routes to auth with the provided redirect path when not signed in', () => {
+    renderWithProviders(
+      <AttendButton
+        currentUserId={null}
+        isOrganizer={false}
+        isAttending={false}
+        onCheckIn={vi.fn()}
+        isLoading={false}
+        mode="linkedin"
+        redirectPath="/event/test-event"
+      />,
+    );
+
+    const link = screen.getByRole('link', {
+      name: /check in with linkedin/i,
+    });
+
+    expect(link).toHaveAttribute('href', '/auth?redirect=%2Fevent%2Ftest-event');
+  });
 });

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useState, useEffect, useMemo } from "react";
+import { useNavigate, Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -17,25 +17,53 @@ import linkbackLogo from "@/assets/linkback-logo.png";
 const Auth = () => {
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const infoItems = TEXT.auth.info.items;
   const infoIcons = [Users, Shield, Lock];
+
+  const redirectPath = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const fromQuery = params.get("redirect");
+
+    if (fromQuery && fromQuery.startsWith("/")) {
+      return fromQuery;
+    }
+
+    if (typeof window !== "undefined") {
+      const stored = sessionStorage.getItem("postAuthRedirect");
+
+      if (stored && stored.startsWith("/")) {
+        return stored;
+      }
+    }
+
+    return "/";
+  }, [location.search]);
 
   useEffect(() => {
     // Check if user is already authenticated
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session) {
-        navigate("/");
+        navigate(redirectPath, { replace: true });
       }
     });
-  }, [navigate]);
+  }, [navigate, redirectPath]);
 
   const handleLinkedInSignIn = async () => {
     setIsLoading(true);
     try {
+      const safeRedirect = redirectPath.startsWith("/") ? redirectPath : "/";
+
+      if (typeof window !== "undefined") {
+        sessionStorage.setItem("postAuthRedirect", safeRedirect);
+      }
+
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "linkedin_oidc",
         options: {
-          redirectTo: `${window.location.origin}/auth/callback`,
+          redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(
+            safeRedirect,
+          )}`,
           scopes: "openid profile email",
         },
       });
@@ -44,6 +72,9 @@ const Auth = () => {
     } catch (error: any) {
       toast.error(error.message || TEXT.auth.toast.failure);
       setIsLoading(false);
+      if (typeof window !== "undefined") {
+        sessionStorage.removeItem("postAuthRedirect");
+      }
     }
   };
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -11,6 +11,7 @@ const AuthCallback = () => {
   const [status, setStatus] = useState<"loading" | "error">("loading");
   const [userId, setUserId] = useState<string | null>(null);
   const [hasHandledProfile, setHasHandledProfile] = useState(false);
+  const [redirectPath, setRedirectPath] = useState<string>("/");
 
   const {
     data: _profile,
@@ -24,11 +25,29 @@ const AuthCallback = () => {
         const params = new URLSearchParams(window.location.search);
         const error = params.get("error");
         const errorDescription = params.get("error_description");
+        const redirectParam = params.get("redirect");
+
+        let resolvedRedirect = "/";
+
+        if (redirectParam && redirectParam.startsWith("/")) {
+          resolvedRedirect = redirectParam;
+        } else if (typeof window !== "undefined") {
+          const stored = sessionStorage.getItem("postAuthRedirect");
+
+          if (stored && stored.startsWith("/")) {
+            resolvedRedirect = stored;
+          }
+        }
+
+        setRedirectPath(resolvedRedirect);
 
         if (error) {
           console.error("OAuth error:", error, errorDescription);
           toast.error(errorDescription || TEXT.authCallback.toast.genericFailure);
           setStatus("error");
+          if (typeof window !== "undefined") {
+            sessionStorage.removeItem("postAuthRedirect");
+          }
           setTimeout(() => navigate("/auth"), 2000);
           return;
         }
@@ -42,6 +61,9 @@ const AuthCallback = () => {
           console.error("Session error:", sessionError);
           toast.error(TEXT.authCallback.toast.sessionFailure);
           setStatus("error");
+          if (typeof window !== "undefined") {
+            sessionStorage.removeItem("postAuthRedirect");
+          }
           setTimeout(() => navigate("/auth"), 2000);
           return;
         }
@@ -49,6 +71,9 @@ const AuthCallback = () => {
         if (!session) {
           toast.error(TEXT.authCallback.toast.noSession);
           setStatus("error");
+          if (typeof window !== "undefined") {
+            sessionStorage.removeItem("postAuthRedirect");
+          }
           setTimeout(() => navigate("/auth"), 2000);
           return;
         }
@@ -62,6 +87,9 @@ const AuthCallback = () => {
             : TEXT.authCallback.toast.genericFailure,
         );
         setStatus("error");
+        if (typeof window !== "undefined") {
+          sessionStorage.removeItem("postAuthRedirect");
+        }
         setTimeout(() => navigate("/auth"), 2000);
       }
     };
@@ -85,8 +113,11 @@ const AuthCallback = () => {
 
     toast.success(TEXT.authCallback.toast.success);
     setHasHandledProfile(true);
-    navigate("/");
-  }, [hasHandledProfile, isProfileLoading, navigate, profileError, userId]);
+    if (typeof window !== "undefined") {
+      sessionStorage.removeItem("postAuthRedirect");
+    }
+    navigate(redirectPath, { replace: true });
+  }, [hasHandledProfile, isProfileLoading, navigate, profileError, redirectPath, userId]);
 
   return (
     <div className="min-h-screen bg-gradient-subtle flex items-center justify-center p-4">

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import {
@@ -39,6 +39,7 @@ import {
 const EventPage = () => {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [isSessionLoading, setIsSessionLoading] = useState(true);
   const [showQRDialog, setShowQRDialog] = useState(false);
@@ -259,6 +260,7 @@ const EventPage = () => {
                 onCheckIn={handleCheckIn}
                 isLoading={joinEvent.isPending}
                 mode="linkedin"
+                redirectPath={`${location.pathname}${location.search}`}
               />
               <p className="text-xs text-center text-muted-foreground px-4">
                 {TEXT.event.page.guestNotice}
@@ -334,6 +336,7 @@ const EventPage = () => {
                 onCheckIn={handleCheckIn}
                 isLoading={joinEvent.isPending}
                 mode="primary"
+                redirectPath={`${location.pathname}${location.search}`}
               />
             </CardContent>
           </Card>

--- a/src/pages/event/components/AttendButton.tsx
+++ b/src/pages/event/components/AttendButton.tsx
@@ -12,6 +12,7 @@ interface AttendButtonProps {
   isLoading: boolean;
   mode?: "primary" | "linkedin";
   className?: string;
+  redirectPath?: string;
 }
 
 const AttendButton = ({
@@ -22,6 +23,7 @@ const AttendButton = ({
   isLoading,
   mode = "primary",
   className,
+  redirectPath,
 }: AttendButtonProps) => {
   if (isOrganizer || isAttending) {
     return null;
@@ -56,7 +58,12 @@ const AttendButton = ({
   );
 
   if (!currentUserId) {
-    return <Link to="/auth">{button}</Link>;
+    const safeRedirectPath = redirectPath?.startsWith("/")
+      ? redirectPath
+      : "/";
+    const authLink = `/auth?redirect=${encodeURIComponent(safeRedirectPath)}`;
+
+    return <Link to={authLink}>{button}</Link>;
   }
 
   return button;


### PR DESCRIPTION
carry the event URL into the auth link so QR guests bounce back after signing in

teach the auth pages to remember and replay the redirect while clearing the stored value on success or error

extend the AttendButton smoke test to cover the new redirect behaviour

## Jira Issue
- LIN-XX

## Summary
Brief description of what this PR does.

## Changes
- Change 1
- Change 2
- Change 3

## Notes
(Optional) Anything important for reviewers to know.