### PR TITLE
[chore] Align auth redirect flow expectations with static callback

### DIFF
--- a/src/__tests__/auth/AuthRedirectFlow.test.tsx
+++ b/src/__tests__/auth/AuthRedirectFlow.test.tsx
@@ -81,7 +81,7 @@ describe("Auth redirect flow", () => {
     expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
       provider: "linkedin_oidc",
       options: {
-        redirectTo: expect.stringContaining("%2Fevent%2Ftest-event"),
+        redirectTo: `${window.location.origin}/auth/callback`,
         scopes: "openid profile email",
       },
     });
@@ -109,7 +109,7 @@ describe("Auth redirect flow", () => {
     expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
       provider: "linkedin_oidc",
       options: {
-        redirectTo: expect.stringContaining("redirect=%2F"),
+        redirectTo: `${window.location.origin}/auth/callback`,
         scopes: "openid profile email",
       },
     });


### PR DESCRIPTION
keep the Supabase OAuth call pointing at the shared /auth/callback origin

update redirect-flow tests to assert only the stored session redirect and OAuth invocation

ensures the suite matches the production-safe login behavior

## Jira Issue

- LIN-XX

## Summary

Brief description of what this PR does.

## Changes

- Change 1
- Change 2
- Change 3

## Notes

(Optional) Anything important for reviewers to know.
