### PR TITLE
[chore] Optimize initial load performance for QR deep links

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,10 @@
     <meta name="twitter:image" content="/og-image.png" />
     <link rel="icon" href="/favicon.png" type="image/png" />
     <link rel="apple-touch-icon" href="/favicon.png" />
+
+    <!-- Preconnect to Supabase for faster API calls -->
+    <link rel="preconnect" href="%VITE_PUBLIC_SUPABASE_URL%" crossorigin />
+    <link rel="dns-prefetch" href="%VITE_PUBLIC_SUPABASE_URL%" />
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "tailwindcss": "^3.4.17",
+        "terser": "^5.44.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
         "vite": "^5.4.19",
@@ -1258,6 +1259,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -4209,6 +4221,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -7757,6 +7776,16 @@
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7764,6 +7793,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stackback": {
@@ -8040,6 +8080,32 @@
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
+      "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.17",
+    "terser": "^5.44.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,33 +18,109 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = new QueryClient();
 
+// Lightweight fallback components
+const PageSkeleton = () => (
+  <div className="min-h-screen flex items-center justify-center">
+    <div className="text-center">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+      <p className="text-muted-foreground">Loading...</p>
+    </div>
+  </div>
+);
+
+const MinimalFallback = () => (
+  <div className="p-4 text-sm text-muted-foreground">Loading...</div>
+);
+
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
       <Toaster />
       <Sonner />
       <BrowserRouter>
-        <Suspense
-          fallback={
-            <div className="min-h-screen flex items-center justify-center text-muted-foreground">
-              Loading...
-            </div>
-          }
-        >
-          <Routes>
-            <Route path="/" element={<Landing />} />
-            <Route path="/auth" element={<Auth />} />
-            <Route path="/auth/callback" element={<AuthCallback />} />
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/create-event" element={<CreateEvent />} />
-            <Route path="/join-event" element={<JoinEvent />} />
-            <Route path="/event/:slug" element={<EventPage />} />
-            <Route path="/event-success/:slug" element={<EventSuccess />} />
-            <Route path="/demo" element={<Demo />} />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </Suspense>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <Suspense fallback={<MinimalFallback />}>
+                <Landing />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/auth"
+            element={
+              <Suspense fallback={<PageSkeleton />}>
+                <Auth />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/auth/callback"
+            element={
+              <Suspense fallback={<PageSkeleton />}>
+                <AuthCallback />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/dashboard"
+            element={
+              <Suspense fallback={<PageSkeleton />}>
+                <Dashboard />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/create-event"
+            element={
+              <Suspense fallback={<PageSkeleton />}>
+                <CreateEvent />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/join-event"
+            element={
+              <Suspense fallback={<PageSkeleton />}>
+                <JoinEvent />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/event/:slug"
+            element={
+              <Suspense fallback={<PageSkeleton />}>
+                <EventPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/event-success/:slug"
+            element={
+              <Suspense fallback={<PageSkeleton />}>
+                <EventSuccess />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/demo"
+            element={
+              <Suspense fallback={<PageSkeleton />}>
+                <Demo />
+              </Suspense>
+            }
+          />
+          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+          <Route
+            path="*"
+            element={
+              <Suspense fallback={<PageSkeleton />}>
+                <NotFound />
+              </Suspense>
+            }
+          />
+        </Routes>
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,11 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
+// Preload EventPage chunk when entering via deep link
+if (location.pathname.startsWith("/event/")) {
+  import("./pages/EventPage").catch(() => {
+    // Non-critical preload — ignore failures, the route will load on demand
+  });
+}
+
 createRoot(document.getElementById("root")!).render(<App />);

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,24 @@
   ],
   "headers": [
     {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/((?!assets/).*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache"
+        }
+      ]
+    },
+    {
       "source": "/auth/callback",
       "headers": [
         {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,18 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    target: "es2020",
+    sourcemap: mode === "development" ? "hidden" : false,
+    minify: "terser",
+    // Raised from Vite's default (500KB) to accommodate the recharts chunk
+    chunkSizeWarningLimit: 900,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          recharts: ["recharts"],
+        },
+      },
+    },
+  },
 }));


### PR DESCRIPTION
## Jira Issue

- N/A

## Summary

Improves first paint and time-to-interactive for the \`/event/:slug\` deep link path, which is the primary entry point for QR code scans at events.

## Changes

- Replace single global \`<Suspense>\` with per-route boundaries — minimal fallback on landing, spinner skeleton on all other pages
- Preload the \`EventPage\` chunk in \`main.tsx\` when the URL starts with \`/event/\`, so the chunk is already fetching before React renders
- Split \`recharts\` into its own chunk — only loads on dashboard, not on the event page
- Add Terser minification and set build target to ES2020
- Add Vercel cache headers: 1-year immutable for \`/assets/*\`, \`no-cache\` for \`index.html\`
- Add Supabase \`preconnect\` and \`dns-prefetch\` hints to \`index.html\`, driven by \`%VITE_PUBLIC_SUPABASE_URL%\` so no project ref is hardcoded

## Notes

The preload check in \`main.tsx\` runs before React Router initialises — this is intentional, it needs to fire as early as possible to get the chunk in-flight.