### PR TITLE
[feature/LIN-22] Add toast notification for organizers scanning their own event

### DIFF
--- a/src/pages/JoinEvent.tsx
+++ b/src/pages/JoinEvent.tsx
@@ -77,6 +77,7 @@ const JoinEvent = () => {
       if (userId && matchingEvent.organizer_id === userId) {
         setIsOwnEvent(true);
         setOwnEventSlug(matchingEvent.slug);
+        toast.info("You're the organizer of this event");
         return;
       }
 


### PR DESCRIPTION
Description:
  ## Jira Issue

  - LIN-22

  ## Summary

  Adds a toast notification when event organizers scan their own QR code, providing clear feedback about why they're shown a "Go to Event" button instead of checking in.

  ## Changes

  - Added `toast.info("You're the organizer of this event")` in `src/pages/JoinEvent.tsx:80` when organizers scan their own event code
  - This provides immediate user feedback explaining the different behavior for organizers

  ## Notes

  Previously, when organizers scanned their own QR code, the UI would silently change to show a "Go to Event" button without any explanation, which was confusing. This toast message clarifies the situation.