### PR TITLE
[chore] Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/block-fixup.yml
+++ b/.github/workflows/block-fixup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary

Pins GitHub Actions to immutable commit SHAs instead of mutable version tags.

## Changes

- `.github/workflows/test.yml`: pin `actions/checkout` to v4.3.1 SHA, `actions/setup-node` to v4.4.0 SHA
- `.github/workflows/block-fixup.yml`: pin `actions/checkout` to v4.3.1 SHA

## Notes

Identified by the gstack security report as a MEDIUM finding. Mutable tags (e.g. `@v4`) can be silently moved to new code — pinning to a SHA guarantees the exact code that runs in CI never changes without a deliberate update to the workflow file.