### PR TITLE
[chore] Trim CLAUDE.md to reduce context overhead

### DIFF
--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -5,18 +5,12 @@ description: Scaffold a new React component for this project — creates the com
 
 # New Component
 
-Scaffold a new React component following this project's conventions.
-
-## Usage
-
 `/new-component <ComponentName> [description]`
 
-## What to create
+Create two files:
 
-Given a component name (PascalCase), create:
-
-1. **`src/components/<ComponentName>.tsx`** — the component file
-2. **`src/__tests__/ui/<ComponentName>.test.tsx`** — a smoke test
+1. **`src/components/<ComponentName>.tsx`**
+2. **`src/__tests__/ui/<ComponentName>.test.tsx`**
 
 ## Component template
 
@@ -51,13 +45,13 @@ describe("<ComponentName>", () => {
 });
 ```
 
-## Conventions to follow
+## Conventions
 
-- Use Shadcn/UI primitives from `@/components/ui/` where appropriate (Button, Card, Dialog, etc.)
-- Use Tailwind for all styling — no inline styles
+- Use Shadcn/UI primitives from `@/components/ui/` where appropriate
+- Tailwind for all styling — no inline styles
 - Use `cn()` from `@/lib/utils` for conditional class merging
 - Props interface always named `<ComponentName>Props`
-- Export as default export (matches existing component conventions in this project)
-- If the component fetches data, use a hook from `useSupabaseData.ts` — don't call Supabase directly from the component
+- Export as default export
+- If the component fetches data, use a hook from `useSupabaseData.ts` — don't call Supabase directly
 
 After creating both files, run `npm run test:run` to confirm the test passes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,215 +1,54 @@
-Claude.md – AI Agent Development Guidelines
+# AI Agent Guidelines
 
-This document provides structured guidelines for AI agents (like Claude Code) contributing to this repository.
+## Branching
 
----
+- Branch from latest main: `feature/<descriptive-name>` or `chore/<descriptive-name>`
+- Make focused, atomic commits — one logical change per commit
+- Use fixup commits while iterating; squash with `git rebase -i --autosquash main` before opening a PR
+- Rebase on latest main before pushing
 
-## Pull Request Workflow
+## Commit Messages
 
-### 1. Branch Creation
+- Capital first letter, imperative mood: "Add feature" not "Added feature"
+- No type prefixes (`fix:`, `feat:`, `chore:` etc.)
+- Be specific: "Add email validation to registration form" not "Update form"
 
-git checkout main && git pull
-git checkout -b feature/<descriptive-name>
+## PR Titles
 
-### 2. Making Changes
+- Feature: `[feature/<name>] Brief description`
+- Everything else: `[chore] Brief description`
 
-- Make focused, atomic commits.
-- Each commit should represent a single logical change.
-- While iterating, use fixup commits:
+## PR Descriptions
 
-git commit --fixup <commit-sha>
+Always use `.github/pull_request_template.md`. When using `gh pr create`, do not pass `--body` — let GitHub auto-populate the template, then fill in every section.
 
-### 3. Before Opening PR
+## Before Opening a PR
 
-# Squash all fixup commits
-
-git rebase -i --autosquash main
-
-# Rebase on latest main
-
-git fetch origin && git rebase origin/main
-
-# Verify everything passes
-
-# Run tests, linting, type checking locally before pushing
-
-# Push branch
-
-git push -u origin feature/<descriptive-name>
-
-### 4. Open Pull Request
-
-IMPORTANT:
-This repository has a pull request template at .github/pull_request_template.md.
-When you open a PR, GitHub will automatically populate the description with this template.
-Always follow the template structure.
-
-# The template will auto-populate when you create the PR
-
-gh pr create --title "[feature/<name>] What is changing"
-
-# Or open PR in browser where the template will appear automatically
-
-gh pr create --web
-
-Do not write custom PR descriptions that deviate from the template. Fill in each section of the template completely.
-
----
-
-## Commit Message Format
-
-### Structure
-
-Capitalize first letter and describe what the commit does
-
-Optional longer description explaining what is changing and why.
-Can span multiple paragraphs if needed.
-
-### Rules
-
-- No prefixes like "chore:", "fix:", "feat:"
-- Start with a capital letter
-- Use imperative mood: "Add feature" not "Added feature"
-- Be specific: "Add validation for email fields" not "Update form"
-
-### Examples
-
-Good:
-Add email validation to registration form
-
-Validates email format and checks for duplicate addresses
-before allowing registration. Prevents invalid emails from
-entering the system.
-
-Bad:
-fix: updated stuff
-
----
-
-## PR Title Format
-
-### Feature Changes
-
-[feature/<name>] Brief description of what is changing
-Example: [feature/add-user-auth] Add user authentication system
-
-### Non-feature Changes (chores, refactoring, etc.)
-
-[chore] Brief description of what is changing
-Example: [chore] Update dependencies to latest versions
-
----
-
-## PR Description
-
-Always use the template from .github/pull_request_template.md
-
-When opening a PR via GitHub’s web interface or CLI, the template will automatically populate.
-Fill in each section:
-
-- What is changing: Clear description of the changes – what files, what functionality
-- Why: The reason/motivation for these changes – what problem does it solve
-- Testing: How was this tested? What scenarios were covered
-- Notes: Additional context, breaking changes, migration steps, etc.
-
-Do not skip sections or deviate from the template structure.
-
----
-
-## Before Requesting Review Checklist
-
-Run through this checklist before marking a PR as ready:
-
-- [ ] Rebased on latest "main" with no conflicts
+- [ ] Rebased on latest main, no conflicts
 - [ ] All fixup commits squashed (history is clean)
-- [ ] Each commit is atomic and meaningful
-- [ ] All tests pass locally
-- [ ] Linting passes
-- [ ] Type checking passes
+- [ ] Tests, linting, and type checking pass locally
 - [ ] Build succeeds
-- [ ] Documentation updated if behavior changed
-- [ ] No console.log or debugging code
-- [ ] No commented-out code blocks
-- [ ] PR follows .github/pull_request_template.md
+- [ ] No `console.log` or commented-out code
+- [ ] Docs updated if behavior changed
 
----
+## Merging
 
-## AI Agent Specific Guidelines
-
-### When to Ask for Human Input
-
-- Before committing: If unsure about scope or correctness
-- Before opening PR: If changes affect critical systems or security
-- Breaking changes: Always confirm with a human
-- Large refactors: Get approval for scope before implementing
-
-### Code Quality Standards
-
-- Prefer explicit over clever code
-- Add comments for complex logic
-- Follow existing patterns
-- Don’t remove code you don’t understand — ask first
-
-### Testing Requirements
-
-- Add tests for new features
-- Update tests when changing behavior
-- Cover edge cases
-- Run full test suite before committing
-
-### File Organization
-
-- Group related changes in the same commit
-- Don’t mix refactoring with feature changes
-- Keep formatting-only changes separate
-
----
-
-## Quick Reference Commands
-
-# Create fixup commit for earlier commit
-
-git add -A
-git commit --fixup <sha>
-
-# Squash all fixups before pushing
-
-git rebase -i --autosquash main
-
-# Update branch with latest main
-
-git fetch origin
-git rebase origin/main
-
-# Force push after rebase (be careful!)
-
-git push --force-with-lease origin feature/<descriptive-name>
-
-# Open PR (template will auto-populate)
-
-gh pr create --title "[feature/<name>] Title"
-
-# or
-
-gh pr create --web
-
----
-
-## Integration to Main
-
-- PRs are merged using merge commits (not squash)
-- Keep branch history clean using fixups + autosquash
-- Rebase onto latest main right before merge
-- All required checks must pass (tests, fixup check, etc.)
-- At least one approving review required
+- Merge commits only (no squash, no rebase merge)
+- 1 approving review required
 - All conversations must be resolved
+- All required checks must pass (test, check-fixup)
 
----
+## Code Quality
 
-## Remember
+- Prefer explicit over clever
+- Follow existing patterns in the codebase
+- Don't remove code you don't understand — ask first
+- Add tests for new features; update tests when changing behavior
+- Don't mix refactoring with feature changes in the same commit
 
-- Clean commits matter – Each commit should be a complete, working change
-- Context is king – Explain the "why," not just the "what"
-- Test everything – Don’t rely on CI to catch basic issues
-- Follow the template – Always use .github/pull_request_template.md
-- Ask when uncertain – Better to ask than to guess
+## When to Ask First
+
+- Changes affecting security or critical systems
+- Breaking changes
+- Large refactors — confirm scope before starting
+- Anything you're unsure about — ask rather than guess

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,48 +2,27 @@
 
 ## Workflow
 
-1. Create a feature branch from `main`:
-   `git checkout main && git pull && git checkout -b feature/<ticket-or-topic>`
-2. Make focused commits. While iterating, use fixups:
-   `git commit --fixup <commit>` and later:
-   `git rebase -i --autosquash main`
-3. Keep history clean in the feature branch (atomic commits, no WIP).
-4. Rebase your branch on the latest `main` before opening/merging the PR:
-   `git fetch origin && git rebase origin/main`
-5. Open a Pull Request into `main`. Title: concise, imperative.
+1. Branch from latest main: `feature/<descriptive-name>` or `chore/<descriptive-name>`
+2. Make focused, atomic commits. Use fixups while iterating; squash before opening a PR.
+3. Rebase on latest main before opening a PR.
+4. Open a Pull Request into `main`.
 
 ## Before requesting review
 
-- Rebased on latest `main` (no conflicts).
-- Fixups squashed (`--autosquash`) so each commit is atomic and meaningful.
-- CI is green (lint / typecheck / tests / build).
-- Update docs/README if behavior changes.
+- Rebased on latest main, no conflicts
+- Fixups squashed — each commit is atomic and meaningful
+- CI is green (lint / typecheck / tests / build)
+- Docs updated if behavior changes
 
 ## Review & merge policy
 
-- At least **1 passing review** required.
-- **Integration method:** Use a **merge commit** when merging to `main`.
-  - We keep commit hygiene via fixups+squash **inside the branch**; do **not** squash on GitHub.
-- **Up-to-date requirement:** Rebase onto latest `main` right before merge.
-- All required checks must pass and all review conversations be resolved.
-- No direct pushes to `main`.
+- At least 1 approving review required
+- Merge commits only — do not squash on GitHub
+- All required checks must pass and all review conversations be resolved
+- No direct pushes to main
 
-## Commit message guidelines
+## Commit messages
 
-- Imperative mood: “Add X”, “Fix Y”.
-- Reference issues/tickets: `LIN-15: …`.
-- Keep commits scoped and testable.
-
-## Local quick refs
-
-```bash
-# fix up an earlier commit, then autosquash
-git add -A
-git commit --fixup <sha>
-git rebase -i --autosquash main
-
-# rebase onto latest main before pushing / merging
-git fetch origin
-git rebase origin/main
-git push -u origin feature/<topic>
-```
+- Imperative mood: "Add X", "Fix Y"
+- No type prefixes (`fix:`, `feat:`, etc.)
+- Keep commits scoped and testable


### PR DESCRIPTION
## Summary

Trims context-heavy markdown files. CLAUDE.md is loaded into every Claude Code session; CONTRIBUTING.md and SKILL.md add overhead when read by agents. Keeping these files lean directly reduces token usage.

## Changes

- `CLAUDE.md`: 215 → 54 lines. Removed Quick Reference Commands, step-by-step git workflow with inline shell commands, good/bad commit examples, and the redundant Remember section. All project-specific rules retained.
- `CONTRIBUTING.md`: 49 → 28 lines. Removed Local quick refs bash block and stale Jira ticket reference (LIN-XX tracking was removed in #49). Tightened workflow steps to rules only.
- `.claude/skills/new-component/SKILL.md`: 63 → 57 lines. Removed redundant intro prose; templates and conventions unchanged.

## Notes

Nothing substantive was removed — only tutorial prose and generic git commands that an agent (or human) already knows.