### PR TITLE
[chore] Fix test suite breakage on Node.js v25

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     globals: true,
-    setupFiles: ["./vitest.setup.ts"],
+    setupFiles: ["./vitest.polyfill.ts", "./vitest.setup.ts"],
     css: true,
   },
   resolve: {

--- a/vitest.polyfill.ts
+++ b/vitest.polyfill.ts
@@ -1,0 +1,28 @@
+// Node.js v25 ships a built-in localStorage that is non-functional without
+// --localstorage-file. msw's CookieStore calls localStorage.getItem at module
+// initialisation, before happy-dom can override globalThis.localStorage.
+// This polyfill file runs as the first setupFiles entry so it completes before
+// vitest.setup.ts (which imports msw) is loaded.
+if (typeof globalThis.localStorage?.getItem !== "function") {
+  const store: Record<string, string> = {};
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      clear: () => {
+        Object.keys(store).forEach((k) => delete store[k]);
+      },
+      get length() {
+        return Object.keys(store).length;
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+    },
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## What is changing

`vitest.polyfill.ts` is added as a new first entry in `setupFiles`. It installs a working in-memory `localStorage` shim before `msw` is loaded.

`vitest.config.ts` is updated to load the polyfill before `vitest.setup.ts`.

## Why

Node.js v25 ships a built-in `localStorage` global. It exists as an object but its methods (`getItem`, `setItem`, etc.) are non-functional unless `--localstorage-file` is passed. `msw`'s `CookieStore` calls `localStorage.getItem` at module-initialisation time — before happy-dom can override `globalThis.localStorage` — so every test suite fails with `TypeError: localStorage.getItem is not a function`.

The fix runs a polyfill module first. Because each `setupFiles` entry is a separate ES module, the polyfill executes completely before `vitest.setup.ts` (which imports `msw`) is loaded. Tests on Node ≤22 are unaffected since the polyfill only triggers when `localStorage.getItem` is missing.

## Testing

All 35 existing tests pass locally on Node v25.8.2. CI (Node 20) is also expected to pass unchanged.

## Notes

This only affects the local dev experience on Node v25. CI uses Node 20 per `.github/workflows/test.yml` and has been green throughout.