### PR TITLE
[feature/checkin-arrival-moment] Add check-in arrival moment

### DIFF
--- a/src/__tests__/routes/EventPage.checkin.test.tsx
+++ b/src/__tests__/routes/EventPage.checkin.test.tsx
@@ -1,0 +1,153 @@
+import { Route, Routes } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils/render";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EventPage from "@/pages/EventPage";
+import { TEXT } from "@/constants/text";
+import { createQueryStub, supabaseStub } from "@/test-utils/supabase";
+
+const BANNER_TEXT = "You're in! Here's who else is coming.";
+
+const baseEvent = {
+  id: "event-1",
+  slug: "launch-day",
+  name: "Launch Day",
+  organizer_id: "organizer-1",
+  starts_at: "2025-05-01T09:00:00.000Z",
+  ends_at: "2025-05-01T11:00:00.000Z",
+  location: "Gothenburg, Sweden",
+};
+
+const organizerProfile = {
+  id: "organizer-1",
+  name: "Organizer One",
+  headline: "Host",
+};
+const attendanceRecord = [{ id: "attendance-1" }];
+
+/**
+ * Sets up Supabase mocks for the check-in arrival tests.
+ *
+ * isAttending=true  → user already attending, full page renders immediately
+ * isAttending=false → user not attending; after insert succeeds, the
+ *                     invalidated attendances refetch returns a record so
+ *                     canViewAttendees flips to true and the full page renders
+ */
+const setupMocks = ({ isAttending }: { isAttending: boolean }) => {
+  supabaseStub.auth.getSession.mockResolvedValue({
+    data: { session: { user: { id: "attendee-1" } } },
+    error: null,
+  });
+
+  const eventQuery = createQueryStub({
+    singleResult: { data: baseEvent, error: null },
+  });
+  eventQuery.select.mockReturnValue(eventQuery);
+  eventQuery.eq.mockReturnValue(eventQuery);
+
+  const profileQuery = createQueryStub({
+    maybeSingleResult: { data: organizerProfile, error: null },
+  });
+  profileQuery.select.mockReturnValue(profileQuery);
+  profileQuery.eq.mockReturnValue(profileQuery);
+
+  // Track whether the join insert has been called so refetches can return data
+  let insertCalled = false;
+
+  const makeAttendancesQuery = (data: unknown[]) => {
+    const q = createQueryStub({ baseResult: { data, error: null } });
+    q.select.mockReturnValue(q);
+    q.eq.mockReturnValue(q);
+    q.insert = vi.fn().mockImplementation(() => {
+      insertCalled = true;
+      return createQueryStub({ baseResult: { data: null, error: null } });
+    });
+    return q;
+  };
+
+  supabaseStub.from.mockImplementation((table: string) => {
+    if (table === "events") return eventQuery;
+    if (table === "profiles") return profileQuery;
+
+    if (table === "attendances") {
+      const hasAttendance = isAttending || insertCalled;
+      return makeAttendancesQuery(hasAttendance ? attendanceRecord : []);
+    }
+
+    return createQueryStub();
+  });
+};
+
+const renderEventPage = () =>
+  renderWithProviders(
+    <Routes>
+      <Route path="/event/:slug" element={<EventPage />} />
+    </Routes>,
+    { route: "/event/launch-day" },
+  );
+
+describe("EventPage check-in arrival moment", () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("does not show the welcome banner on a plain page load", async () => {
+    setupMocks({ isAttending: true });
+    renderEventPage();
+
+    await screen.findByText(baseEvent.name);
+
+    expect(screen.queryByText(BANNER_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("shows the welcome banner after a successful check-in", async () => {
+    setupMocks({ isAttending: false });
+    renderEventPage();
+
+    const checkInButton = await screen.findByRole("button", {
+      name: TEXT.event.attendButton.checkInLinkedIn,
+    });
+
+    await userEvent.click(checkInButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(BANNER_TEXT)).toBeInTheDocument();
+    });
+  });
+
+  it("dismisses the banner when the X button is clicked", async () => {
+    setupMocks({ isAttending: false });
+    renderEventPage();
+
+    const checkInButton = await screen.findByRole("button", {
+      name: TEXT.event.attendButton.checkInLinkedIn,
+    });
+    await userEvent.click(checkInButton);
+
+    const dismissButton = await screen.findByRole("button", {
+      name: "Dismiss",
+    });
+    await userEvent.click(dismissButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText(BANNER_TEXT)).not.toBeInTheDocument();
+    });
+  });
+
+  it("scrolls to the attendee list after attendee data loads", async () => {
+    const scrollIntoView = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    setupMocks({ isAttending: false });
+    renderEventPage();
+
+    const checkInButton = await screen.findByRole("button", {
+      name: TEXT.event.attendButton.checkInLinkedIn,
+    });
+    await userEvent.click(checkInButton);
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
+    });
+  });
+});

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -9,7 +9,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, CheckCircle, X } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { toast } from "sonner";
 import { QRCodeDialog } from "@/components/QRCodeDialog";
 import EventHeader from "@/pages/event/components/EventHeader";
@@ -45,6 +46,8 @@ const EventPage = () => {
   const [isSessionLoading, setIsSessionLoading] = useState(true);
   const [showQRDialog, setShowQRDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [justJoined, setJustJoined] = useState(false);
+  const attendeeListRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let isMounted = true;
@@ -127,6 +130,12 @@ const EventPage = () => {
   const isLoading =
     isSessionLoading || isEventLoading || isUserAttendanceLoading;
 
+  useEffect(() => {
+    if (justJoined && !isAttendeesLoading) {
+      attendeeListRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [justJoined, isAttendeesLoading]);
+
   const joinEvent = useJoinEvent();
   const deleteEvent = useDeleteEvent();
 
@@ -149,6 +158,7 @@ const EventPage = () => {
       });
 
       toast.success(TEXT.event.toast.checkInSuccess);
+      setJustJoined(true);
     } catch (error) {
       if (
         typeof error === "object" &&
@@ -338,12 +348,29 @@ const EventPage = () => {
             </CardContent>
           </Card>
 
-          <AttendeeList
-            attendees={attendees}
-            currentUserId={currentUserId}
-            isOrganizer={isOrganizer}
-            isLoading={isAttendeesLoading}
-          />
+          <div ref={attendeeListRef}>
+            {justJoined && (
+              <Alert className="mb-4">
+                <CheckCircle className="h-4 w-4" />
+                <AlertDescription className="flex items-center justify-between">
+                  <span>You're in! Here's who else is coming.</span>
+                  <button
+                    onClick={() => setJustJoined(false)}
+                    className="ml-4 text-muted-foreground hover:text-foreground"
+                    aria-label="Dismiss"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </AlertDescription>
+              </Alert>
+            )}
+            <AttendeeList
+              attendees={attendees}
+              currentUserId={currentUserId}
+              isOrganizer={isOrganizer}
+              isLoading={isAttendeesLoading}
+            />
+          </div>
         </div>
       </main>
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     globals: true,
-    setupFiles: ["./vitest.setup.ts"],
+    setupFiles: ["./vitest.polyfill.ts", "./vitest.setup.ts"],
     css: true,
   },
   resolve: {

--- a/vitest.polyfill.ts
+++ b/vitest.polyfill.ts
@@ -1,0 +1,28 @@
+// Node.js v25 ships a built-in localStorage that is non-functional without
+// --localstorage-file. msw's CookieStore calls localStorage.getItem at module
+// initialisation, before happy-dom can override globalThis.localStorage.
+// This polyfill file runs as the first setupFiles entry so it completes before
+// vitest.setup.ts (which imports msw) is loaded.
+if (typeof globalThis.localStorage?.getItem !== "function") {
+  const store: Record<string, string> = {};
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      clear: () => {
+        Object.keys(store).forEach((k) => delete store[k]);
+      },
+      get length() {
+        return Object.keys(store).length;
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+    },
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## What is changing

`src/pages/EventPage.tsx` — after a successful check-in, a dismissible welcome banner appears above the attendee list and the page scrolls to it. The scroll fires only once attendee data has loaded.

`src/__tests__/routes/EventPage.checkin.test.tsx` — 4 new tests.

The feature branch includes `chore/fix-node25-localstorage-test` as a base (PR #56) to unblock local test runs on Node v25.

## Why

When an attendee scans a QR code and joins an event, they land on EventPage with no acknowledgement of the moment. The attendee list — the whole point of the LinkedIn integration — is buried below event details. This adds a "you're in, here's who's here" arrival experience.

## Testing

- 39/39 tests pass locally (Node v25.8.2)
- Manual: scan QR → check in → banner appears, page scrolls to attendee list → X dismisses banner → URL stays clean

## Notes

Depends on PR #56 (`chore/fix-node25-localstorage-test`) for Node v25 test compatibility. If reviewing, merge #56 first and this branch will rebase cleanly onto main.