### PR TITLE
[chore] Optimize Join Event lookup with short_code

### DIFF
--- a/src/hooks/useSupabaseData.ts
+++ b/src/hooks/useSupabaseData.ts
@@ -74,11 +74,13 @@ export const useEvent = (identifier?: EventIdentifier) => {
 
 type UseEventsOptions = {
   organizerId?: string;
+  shortCode?: string;
   enabled?: boolean;
 };
 
 const normalizeEventsOptions = (options?: UseEventsOptions) => ({
   organizerId: options?.organizerId ?? undefined,
+  shortCode: options?.shortCode ?? undefined,
 });
 
 export const eventsQueryKey = (options?: UseEventsOptions) => [
@@ -94,6 +96,10 @@ export const fetchEvents = async (
 
   if (normalized.organizerId) {
     query = query.eq("organizer_id", normalized.organizerId);
+  }
+
+  if (normalized.shortCode) {
+    query = query.eq("short_code", normalized.shortCode);
   }
 
   query = query.order("created_at", { ascending: false });

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -67,6 +67,7 @@ export type Database = {
           location: string | null;
           name: string;
           organizer_id: string;
+          short_code: string;
           slug: string;
           starts_at: string | null;
           ends_at: string;
@@ -79,6 +80,7 @@ export type Database = {
           location?: string | null;
           name: string;
           organizer_id: string;
+          short_code?: string;
           slug: string;
           starts_at?: string | null;
           ends_at: string;
@@ -91,6 +93,7 @@ export type Database = {
           location?: string | null;
           name?: string;
           organizer_id?: string;
+          short_code?: string;
           slug?: string;
           starts_at?: string | null;
           ends_at?: string;

--- a/src/pages/JoinEvent.tsx
+++ b/src/pages/JoinEvent.tsx
@@ -34,14 +34,6 @@ const JoinEvent = () => {
     ? TEXT.common.links.backToDashboard
     : TEXT.common.links.backToHome;
 
-  const generateEventCode = (eventId: string): string => {
-    return Math.abs(
-      parseInt(eventId.replace(/-/g, "").substring(0, 8), 16) % 1000000,
-    )
-      .toString()
-      .padStart(6, "0");
-  };
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!eventCode.trim()) {
@@ -60,13 +52,12 @@ const JoinEvent = () => {
       } = await supabase.auth.getSession();
       const userId = session?.user?.id;
 
-      // Fetch all events to find matching code
-      const events = await fetchEventsWithClient(queryClient);
+      // Fetch only the event with the matching short code
+      const events = await fetchEventsWithClient(queryClient, {
+        shortCode: eventCode.trim(),
+      });
 
-      // Find event with matching code
-      const matchingEvent = events?.find(
-        (event) => generateEventCode(event.id) === eventCode.trim(),
-      );
+      const matchingEvent = events?.[0];
 
       if (!matchingEvent) {
         toast.error(TEXT.joinEvent.toast.notFound);

--- a/supabase/migrations/20260402000000_add_event_short_code.sql
+++ b/supabase/migrations/20260402000000_add_event_short_code.sql
@@ -2,10 +2,10 @@
 -- This mirrors the logic in src/lib/events.ts: eventCodeFromId
 
 -- 1. Add the column
-ALTER TABLE events ADD COLUMN IF NOT EXISTS short_code text;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS short_code text;
 
 -- 2. Create a function to derive the code from ID
-CREATE OR REPLACE FUNCTION derive_event_short_code(event_id uuid) 
+CREATE OR REPLACE FUNCTION derive_event_short_code(event_id uuid)
 RETURNS text AS $$
 BEGIN
   -- Replicates: Math.abs(parseInt(id.replace(/-/g, "").substring(0, 8), 16) % 1000000).toString().padStart(6, "0")
@@ -14,16 +14,13 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- 3. Backfill existing records
-UPDATE events SET short_code = derive_event_short_code(id) WHERE short_code IS NULL;
+UPDATE public.events SET short_code = derive_event_short_code(id) WHERE short_code IS NULL;
 
 -- 4. Make it NOT NULL and UNIQUE
-ALTER TABLE events ALTER COLUMN short_code SET NOT NULL;
-ALTER TABLE events ADD CONSTRAINT events_short_code_key UNIQUE (short_code);
+ALTER TABLE public.events ALTER COLUMN short_code SET NOT NULL;
+ALTER TABLE public.events ADD CONSTRAINT events_short_code_key UNIQUE (short_code);
 
--- 5. Create an index for O(1) lookups
-CREATE INDEX IF NOT EXISTS idx_events_short_code ON events (short_code);
-
--- 6. Create a trigger to auto-populate on insert
+-- 5. Create a trigger to auto-populate on insert
 CREATE OR REPLACE FUNCTION populate_event_short_code()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -35,6 +32,6 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER trg_populate_event_short_code
-BEFORE INSERT ON events
+BEFORE INSERT ON public.events
 FOR EACH ROW
 EXECUTE FUNCTION populate_event_short_code();

--- a/supabase/migrations/20260402000000_add_event_short_code.sql
+++ b/supabase/migrations/20260402000000_add_event_short_code.sql
@@ -1,0 +1,40 @@
+-- Migration to add short_code to events for faster lookups
+-- This mirrors the logic in src/lib/events.ts: eventCodeFromId
+
+-- 1. Add the column
+ALTER TABLE events ADD COLUMN IF NOT EXISTS short_code text;
+
+-- 2. Create a function to derive the code from ID
+CREATE OR REPLACE FUNCTION derive_event_short_code(event_id uuid) 
+RETURNS text AS $$
+BEGIN
+  -- Replicates: Math.abs(parseInt(id.replace(/-/g, "").substring(0, 8), 16) % 1000000).toString().padStart(6, "0")
+  RETURN LPAD((('x' || substring(replace(event_id::text, '-', '') from 1 for 8))::bit(32)::bigint % 1000000)::text, 6, '0');
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- 3. Backfill existing records
+UPDATE events SET short_code = derive_event_short_code(id) WHERE short_code IS NULL;
+
+-- 4. Make it NOT NULL and UNIQUE
+ALTER TABLE events ALTER COLUMN short_code SET NOT NULL;
+ALTER TABLE events ADD CONSTRAINT events_short_code_key UNIQUE (short_code);
+
+-- 5. Create an index for O(1) lookups
+CREATE INDEX IF NOT EXISTS idx_events_short_code ON events (short_code);
+
+-- 6. Create a trigger to auto-populate on insert
+CREATE OR REPLACE FUNCTION populate_event_short_code()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.short_code IS NULL THEN
+    NEW.short_code := derive_event_short_code(NEW.id);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_populate_event_short_code
+BEFORE INSERT ON events
+FOR EACH ROW
+EXECUTE FUNCTION populate_event_short_code();


### PR DESCRIPTION
## Description
Optimizes the "Join by Code" flow by moving the lookup logic from the client to the server.

### Key Changes
- **Migration**: Added `short_code` column to `events` table with a unique constraint and index.
- **Trigger**: Added a database trigger to auto-populate the `short_code` using the established derivation logic.
- **Hook**: Updated `fetchEvents` to support an optional `shortCode` filter.
- **Frontend**: Refactored `JoinEvent.tsx` to fetch only the matching event instead of scanning all events locally.

### Performance Impact
- Before: **O(N)** complexity (Fetches all events and filters in JS).
- After: **O(1)** complexity (Direct indexed database lookup).

## Type of change
- [x] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Verified that new events correctly generate 6-digit short codes via the trigger.
- Verified that existing events were backfilled correctly by the migration logic.
- Verified "Join by Code" still works correctly with the optimized query.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Build succeeds locally