### PR TITLE
[feature/fix-oauth-redirect] Fix ghost redirect after LinkedIn OAuth

### DIFF
--- a/src/__tests__/auth/AuthRedirectFlow.test.tsx
+++ b/src/__tests__/auth/AuthRedirectFlow.test.tsx
@@ -6,7 +6,7 @@ import Auth from "@/pages/Auth";
 import AuthCallback from "@/pages/AuthCallback";
 import { TEXT } from "@/constants/text";
 import type { Mock } from "vitest";
-import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockNavigate = vi.fn();
 
@@ -38,23 +38,18 @@ vi.mock("sonner", async () => {
 
 const getSessionMock = supabase.auth.getSession as unknown as Mock;
 const signInMock = supabase.auth.signInWithOAuth as unknown as Mock;
+const onAuthStateChangeMock = supabase.auth
+  .onAuthStateChange as unknown as Mock;
 
 const configureSignIn = () =>
-  signInMock.mockResolvedValue({
-    data: null,
-    error: null,
-  });
+  signInMock.mockResolvedValue({ data: null, error: null });
 
 describe("Auth redirect flow", () => {
   beforeEach(() => {
-    sessionStorage.clear();
     mockNavigate.mockReset();
     signInMock.mockClear();
     getSessionMock.mockClear();
-  });
-
-  afterEach(() => {
-    sessionStorage.clear();
+    onAuthStateChangeMock.mockReset();
   });
 
   it("preserves a safe redirect path from the query string when starting OAuth", async () => {
@@ -75,13 +70,10 @@ describe("Auth redirect flow", () => {
       }),
     );
 
-    expect(sessionStorage.getItem("postAuthRedirect")).toBe(
-      "/event/test-event",
-    );
     expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
       provider: "linkedin_oidc",
       options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
+        redirectTo: `${window.location.origin}/auth/callback?next=%2Fevent%2Ftest-event`,
         scopes: "openid profile email",
       },
     });
@@ -105,27 +97,25 @@ describe("Auth redirect flow", () => {
       }),
     );
 
-    expect(sessionStorage.getItem("postAuthRedirect")).toBe("/");
     expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
       provider: "linkedin_oidc",
       options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
+        redirectTo: `${window.location.origin}/auth/callback?next=%2F`,
         scopes: "openid profile email",
       },
     });
   });
 
-  it("navigates back to the stored path on successful callback", async () => {
+  it("navigates to the next path encoded in the callback URL on successful auth", async () => {
     mockNavigate.mockReset();
-    getSessionMock.mockResolvedValue({
-      data: { session: { user: { id: "user_test" } } },
-      error: null,
+
+    onAuthStateChangeMock.mockImplementation((cb) => {
+      queueMicrotask(() => cb("SIGNED_IN", { user: { id: "user_test" } }));
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
     });
 
-    sessionStorage.setItem("postAuthRedirect", "/event/test-event");
-
     renderWithProviders(<AuthCallback />, {
-      route: "/auth/callback?redirect=/event/test-event",
+      route: "/auth/callback?next=%2Fevent%2Ftest-event",
     });
 
     await waitFor(() => {
@@ -133,7 +123,46 @@ describe("Auth redirect flow", () => {
         replace: true,
       });
     });
+  });
 
-    expect(sessionStorage.getItem("postAuthRedirect")).toBeNull();
+  it("navigates to the next path on INITIAL_SESSION with valid session", async () => {
+    mockNavigate.mockReset();
+
+    onAuthStateChangeMock.mockImplementation((cb) => {
+      queueMicrotask(() =>
+        cb("INITIAL_SESSION", { user: { id: "user_test" } }),
+      );
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+
+    renderWithProviders(<AuthCallback />, {
+      route: "/auth/callback?next=%2Fdashboard",
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard", {
+        replace: true,
+      });
+    });
+  });
+
+  it("redirects to auth on failed session establishment", async () => {
+    mockNavigate.mockReset();
+
+    onAuthStateChangeMock.mockImplementation((cb) => {
+      queueMicrotask(() => cb("SIGNED_OUT", null));
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+
+    renderWithProviders(<AuthCallback />, {
+      route: "/auth/callback",
+    });
+
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith("/auth");
+      },
+      { timeout: 3000 },
+    );
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Validates that a redirect path is internal to the application.
+ * Prevents protocol-relative URLs (//evil.com) and absolute URLs.
+ */
+export function isSafeRedirect(path: string | null | undefined): boolean {
+  if (!path || typeof path !== "string") return false;
+  return path.startsWith("/") && !path.startsWith("//") && !path.includes("\\");
+}

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 import { Linkedin, Shield, Users, Lock } from "lucide-react";
 import { TEXT } from "@/constants/text";
 import linkbackLogo from "@/assets/linkback-logo.png";
+import { isSafeRedirect } from "@/lib/utils";
 
 const Auth = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -25,23 +26,14 @@ const Auth = () => {
     const params = new URLSearchParams(location.search);
     const fromQuery = params.get("redirect");
 
-    if (fromQuery && fromQuery.startsWith("/")) {
-      return fromQuery;
-    }
-
-    if (typeof window !== "undefined") {
-      const stored = sessionStorage.getItem("postAuthRedirect");
-
-      if (stored && stored.startsWith("/")) {
-        return stored;
-      }
+    if (isSafeRedirect(fromQuery)) {
+      return fromQuery as string;
     }
 
     return "/";
   }, [location.search]);
 
   useEffect(() => {
-    // Check if user is already authenticated
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session) {
         navigate(redirectPath, { replace: true });
@@ -52,16 +44,12 @@ const Auth = () => {
   const handleLinkedInSignIn = async () => {
     setIsLoading(true);
     try {
-      const safeRedirect = redirectPath.startsWith("/") ? redirectPath : "/";
-
-      if (typeof window !== "undefined") {
-        sessionStorage.setItem("postAuthRedirect", safeRedirect);
-      }
+      const safeRedirect = isSafeRedirect(redirectPath) ? redirectPath : "/";
 
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "linkedin_oidc",
         options: {
-          redirectTo: `${window.location.origin}/auth/callback`,
+          redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(safeRedirect)}`,
           scopes: "openid profile email",
         },
       });
@@ -72,9 +60,6 @@ const Auth = () => {
         error instanceof Error ? error.message : TEXT.auth.toast.failure;
       toast.error(message);
       setIsLoading(false);
-      if (typeof window !== "undefined") {
-        sessionStorage.removeItem("postAuthRedirect");
-      }
     }
   };
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,17 +1,24 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { useMyProfile } from "@/hooks/useProfile";
 import { toast } from "sonner";
 import { QrCode } from "lucide-react";
 import { TEXT } from "@/constants/text";
+import { isSafeRedirect } from "@/lib/utils";
 
 const AuthCallback = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const [status, setStatus] = useState<"loading" | "error">("loading");
   const [userId, setUserId] = useState<string | null>(null);
   const [hasHandledProfile, setHasHandledProfile] = useState(false);
-  const [redirectPath, setRedirectPath] = useState<string>("/");
+
+  const redirectPath = (() => {
+    const params = new URLSearchParams(location.search);
+    const next = params.get("next");
+    return isSafeRedirect(next) ? (next as string) : "/";
+  })();
 
   const {
     data: _profile,
@@ -20,84 +27,41 @@ const AuthCallback = () => {
   } = useMyProfile(userId ?? undefined);
 
   useEffect(() => {
-    const handleAuthCallback = async () => {
-      try {
-        const params = new URLSearchParams(window.location.search);
-        const error = params.get("error");
-        const errorDescription = params.get("error_description");
-        const redirectParam = params.get("redirect");
+    const params = new URLSearchParams(location.search);
+    const error = params.get("error");
+    const errorDescription = params.get("error_description");
 
-        let resolvedRedirect = "/";
+    if (error) {
+      console.error("OAuth error:", error, errorDescription);
+      toast.error(errorDescription || TEXT.authCallback.toast.genericFailure);
+      setStatus("error");
+      setTimeout(() => navigate("/auth"), 2000);
+      return;
+    }
 
-        if (redirectParam && redirectParam.startsWith("/")) {
-          resolvedRedirect = redirectParam;
-        } else if (typeof window !== "undefined") {
-          const stored = sessionStorage.getItem("postAuthRedirect");
-
-          if (stored && stored.startsWith("/")) {
-            resolvedRedirect = stored;
-          }
-        }
-
-        setRedirectPath(resolvedRedirect);
-
-        if (error) {
-          console.error("OAuth error:", error, errorDescription);
-          toast.error(
-            errorDescription || TEXT.authCallback.toast.genericFailure,
-          );
-          setStatus("error");
-          if (typeof window !== "undefined") {
-            sessionStorage.removeItem("postAuthRedirect");
-          }
-          setTimeout(() => navigate("/auth"), 2000);
-          return;
-        }
-
-        const {
-          data: { session },
-          error: sessionError,
-        } = await supabase.auth.getSession();
-
-        if (sessionError) {
-          console.error("Session error:", sessionError);
-          toast.error(TEXT.authCallback.toast.sessionFailure);
-          setStatus("error");
-          if (typeof window !== "undefined") {
-            sessionStorage.removeItem("postAuthRedirect");
-          }
-          setTimeout(() => navigate("/auth"), 2000);
-          return;
-        }
-
-        if (!session) {
-          toast.error(TEXT.authCallback.toast.noSession);
-          setStatus("error");
-          if (typeof window !== "undefined") {
-            sessionStorage.removeItem("postAuthRedirect");
-          }
-          setTimeout(() => navigate("/auth"), 2000);
-          return;
-        }
-
+    // onAuthStateChange is more reliable than getSession() at callback time —
+    // it waits for Supabase to finish processing the token from the URL fragment.
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if ((event === "SIGNED_IN" || event === "INITIAL_SESSION") && session) {
         setUserId(session.user.id);
-      } catch (error: unknown) {
-        console.error("Auth callback error:", error);
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : TEXT.authCallback.toast.genericFailure,
-        );
+        subscription.unsubscribe();
+        return;
+      }
+
+      if (event === "SIGNED_OUT" || (!session && event !== "INITIAL_SESSION")) {
+        toast.error(TEXT.authCallback.toast.noSession);
         setStatus("error");
-        if (typeof window !== "undefined") {
-          sessionStorage.removeItem("postAuthRedirect");
-        }
+        subscription.unsubscribe();
         setTimeout(() => navigate("/auth"), 2000);
       }
-    };
+    });
 
-    handleAuthCallback();
-  }, [navigate]);
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [location.search, navigate]);
 
   useEffect(() => {
     if (!userId || isProfileLoading || hasHandledProfile) {
@@ -115,9 +79,6 @@ const AuthCallback = () => {
 
     toast.success(TEXT.authCallback.toast.success);
     setHasHandledProfile(true);
-    if (typeof window !== "undefined") {
-      sessionStorage.removeItem("postAuthRedirect");
-    }
     navigate(redirectPath, { replace: true });
   }, [
     hasHandledProfile,


### PR DESCRIPTION
## Summary

- Replace `sessionStorage` with a `?next=<encoded-path>` query param in the `redirectTo` URL passed to Supabase
- Switch `AuthCallback` from `getSession()` to `onAuthStateChange` so it waits for Supabase to finish processing the token rather than sampling once at render time
- Remove all `sessionStorage` read/write from both `Auth.tsx` and `AuthCallback.tsx`

## Why

`sessionStorage` is scoped to the exact origin. When Supabase/LinkedIn redirects back via the primary Site URL (e.g. `linked-list.vercel.app`) instead of the preview URL where the flow started (e.g. `linked-list-abc123.vercel.app`), the stored redirect path is invisible and the user lands on `/` instead of their intended destination.

Encoding the destination in the URL itself means it survives any origin change during the OAuth handshake — Supabase and LinkedIn are required to preserve query params on the callback URL.

## Test plan

- [ ] Sign in from a Vercel preview URL and verify you land on the correct page after auth
- [ ] Sign in from an event page deep link and verify you return to that event after auth
- [ ] Verify an unsafe redirect (absolute URL) still falls back to `/`
- [ ] All 39 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)