### PR TITLE
[feature/comprehensive-test-coverage] Add comprehensive tests and Playwright e2e setup

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+import { TEXT } from "../src/constants/text";
+
+test.describe("Auth page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/auth");
+  });
+
+  test("renders the sign-in card title", async ({ page }) => {
+    await expect(page.getByText(TEXT.auth.card.title)).toBeVisible();
+  });
+
+  test("shows the LinkedIn sign-in button in its idle state", async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole("button", { name: TEXT.auth.card.buttonIdle }),
+    ).toBeVisible();
+  });
+
+  test("shows what data LinkedIn access requires", async ({ page }) => {
+    await expect(page.getByText(TEXT.auth.info.title)).toBeVisible();
+  });
+
+  test("has a link back to the home page", async ({ page }) => {
+    const backLink = page.getByRole("link", {
+      name: TEXT.auth.navigation.backToHome,
+    });
+    await expect(backLink).toBeVisible();
+    await expect(backLink).toHaveAttribute("href", "/");
+  });
+});

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+import { TEXT } from "../src/constants/text";
+
+test.describe("Landing page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("has a single level-one heading", async ({ page }) => {
+    const headings = page.getByRole("heading", { level: 1 });
+    await expect(headings).toHaveCount(1);
+  });
+
+  test("displays the hero title text", async ({ page }) => {
+    await expect(page.getByText(TEXT.landing.hero.titleLine)).toBeVisible();
+  });
+
+  test("shows the 'How It Works' section", async ({ page }) => {
+    await expect(page.getByText(TEXT.landing.howItWorks.title)).toBeVisible();
+  });
+
+  test("has a link to the auth page for unauthenticated visitors", async ({
+    page,
+  }) => {
+    const signInLink = page
+      .getByRole("link", { name: TEXT.landing.hero.signInButton })
+      .first();
+    await expect(signInLink).toBeVisible();
+  });
+
+  test("renders the page title in the document head", async ({ page }) => {
+    await expect(page).toHaveTitle(/LinkBack/i);
+  });
+});

--- a/e2e/not-found.spec.ts
+++ b/e2e/not-found.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "@playwright/test";
+import { TEXT } from "../src/constants/text";
+
+test.describe("Not Found page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/this-route-does-not-exist");
+  });
+
+  test("renders the 404 heading", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: TEXT.notFound.title }),
+    ).toBeVisible();
+  });
+
+  test("shows the page-not-found subtitle", async ({ page }) => {
+    await expect(page.getByText(TEXT.notFound.subtitle)).toBeVisible();
+  });
+
+  test("has a link back to the home page", async ({ page }) => {
+    const homeLink = page.getByRole("link", { name: TEXT.notFound.link });
+    await expect(homeLink).toBeVisible();
+    await expect(homeLink).toHaveAttribute("href", "/");
+  });
+
+  test("navigates back to the landing page when the link is clicked", async ({
+    page,
+  }) => {
+    await page.getByRole("link", { name: TEXT.notFound.link }).click();
+    await expect(page).toHaveURL("/");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "linked-list",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",
@@ -62,6 +63,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -1369,6 +1371,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6991,6 +7009,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -68,6 +70,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:8080",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:8080",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/src/__tests__/lib/events.test.ts
+++ b/src/__tests__/lib/events.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import {
+  eventCodeFromId,
+  generateSlug,
+  parseEventDateParts,
+  combineEventDateAndTime,
+} from "@/lib/events";
+
+describe("eventCodeFromId", () => {
+  it("returns a 6-character string", () => {
+    const code = eventCodeFromId("550e8400-e29b-41d4-a716-446655440000");
+    expect(code).toHaveLength(6);
+  });
+
+  it("pads with leading zeros when the hash value is small", () => {
+    const code = eventCodeFromId("00000000-0000-0000-0000-000000000000");
+    expect(code).toMatch(/^\d{6}$/);
+  });
+
+  it("produces a consistent result for the same input", () => {
+    const id = "550e8400-e29b-41d4-a716-446655440000";
+    expect(eventCodeFromId(id)).toBe(eventCodeFromId(id));
+  });
+
+  it("produces different codes for different UUIDs", () => {
+    const code1 = eventCodeFromId("aaaaaaaa-0000-0000-0000-000000000000");
+    const code2 = eventCodeFromId("bbbbbbbb-0000-0000-0000-000000000000");
+    expect(code1).not.toBe(code2);
+  });
+
+  it("only contains digits", () => {
+    const code = eventCodeFromId("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+    expect(code).toMatch(/^\d+$/);
+  });
+});
+
+describe("generateSlug", () => {
+  it("lowercases the input", () => {
+    const slug = generateSlug("Tech Meetup");
+    expect(slug).toMatch(/^tech-meetup-/);
+  });
+
+  it("replaces spaces with hyphens", () => {
+    const slug = generateSlug("my event name");
+    expect(slug).toMatch(/^my-event-name-/);
+  });
+
+  it("removes special characters", () => {
+    const slug = generateSlug("Hello, World! 2025");
+    expect(slug).toMatch(/^hello-world-2025-/);
+  });
+
+  it("appends a random 6-character alphanumeric suffix", () => {
+    const slug = generateSlug("Event");
+    const parts = slug.split("-");
+    const suffix = parts[parts.length - 1];
+    expect(suffix).toMatch(/^[a-z0-9]{6}$/);
+  });
+
+  it("falls back to 'event' base when name is empty", () => {
+    const slug = generateSlug("");
+    expect(slug).toMatch(/^event-/);
+  });
+
+  it("falls back to 'event' base when name contains only special characters", () => {
+    const slug = generateSlug("!!!---");
+    expect(slug).toMatch(/^event-/);
+  });
+
+  it("produces unique slugs for the same name across calls", () => {
+    const randomSpy = vi.spyOn(Math, "random");
+    randomSpy.mockReturnValueOnce(0.1).mockReturnValueOnce(0.9);
+    const slug1 = generateSlug("Meetup");
+    const slug2 = generateSlug("Meetup");
+    expect(slug1).not.toBe(slug2);
+    randomSpy.mockRestore();
+  });
+
+  it("trims leading and trailing hyphens from the base", () => {
+    const slug = generateSlug("-hello-");
+    expect(slug).toMatch(/^hello-/);
+  });
+});
+
+describe("parseEventDateParts", () => {
+  it("returns empty strings when input is null", () => {
+    expect(parseEventDateParts(null)).toEqual({ date: "", time: "" });
+  });
+
+  it("returns empty strings when input is undefined", () => {
+    expect(parseEventDateParts(undefined)).toEqual({ date: "", time: "" });
+  });
+
+  it("returns empty strings when input is an empty string", () => {
+    expect(parseEventDateParts("")).toEqual({ date: "", time: "" });
+  });
+
+  it("parses a valid ISO string into date and time parts", () => {
+    const result = parseEventDateParts("2025-05-15T14:30:00.000Z");
+    expect(result.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.time).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it("extracts the correct date from an ISO string", () => {
+    // Use noon UTC so the local date stays 2025-03-01 in every timezone (UTC-11 to UTC+12)
+    const result = parseEventDateParts("2025-03-01T12:00:00.000Z");
+    expect(result.date).toBe("2025-03-01");
+  });
+
+  it("returns empty strings for a clearly malformed date string", () => {
+    const result = parseEventDateParts("not-a-date");
+    expect(result.date).toBe("");
+    expect(result.time).toBe("");
+  });
+});
+
+describe("combineEventDateAndTime", () => {
+  it("returns null when date is empty", () => {
+    expect(combineEventDateAndTime("", "10:00")).toBeNull();
+  });
+
+  it("returns null when time is empty", () => {
+    expect(combineEventDateAndTime("2025-05-01", "")).toBeNull();
+  });
+
+  it("returns null when both date and time are empty", () => {
+    expect(combineEventDateAndTime("", "")).toBeNull();
+  });
+
+  it("returns an ISO string for valid date and time inputs", () => {
+    const result = combineEventDateAndTime("2025-05-01", "09:00");
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe("string");
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("round-trips with parseEventDateParts to produce the original date and time", () => {
+    // combineEventDateAndTime stores local time as UTC, so the UTC string may show
+    // a different calendar date. Test the round-trip instead.
+    const result = combineEventDateAndTime("2025-12-25", "18:00");
+    expect(result).not.toBeNull();
+    const { date, time } = parseEventDateParts(result);
+    expect(date).toBe("2025-12-25");
+    expect(time).toBe("18:00");
+  });
+
+  it("returns null for a date that produces NaN", () => {
+    const result = combineEventDateAndTime("not-a-date", "10:00");
+    expect(result).toBeNull();
+  });
+});

--- a/src/__tests__/smoke/EventSuccess.test.tsx
+++ b/src/__tests__/smoke/EventSuccess.test.tsx
@@ -1,0 +1,87 @@
+import { renderWithProviders } from "@/test-utils/render";
+import { supabase } from "@/integrations/supabase/client";
+import { Route, Routes } from "react-router-dom";
+import { screen } from "@testing-library/react";
+import { vi } from "vitest";
+import EventSuccess from "@/pages/EventSuccess";
+import { TEXT } from "@/constants/text";
+import { eventCodeFromId } from "@/lib/events";
+
+describe("EventSuccess smoke", () => {
+  const eventId = "550e8400-e29b-41d4-a716-446655440000";
+  const event = {
+    id: eventId,
+    slug: "launch-day",
+    name: "Launch Day",
+    organizer_id: "organizer-1",
+    starts_at: null,
+    ends_at: null,
+    location: null,
+  };
+
+  const renderPage = () =>
+    renderWithProviders(
+      <Routes>
+        <Route path="/event-success/:slug" element={<EventSuccess />} />
+        <Route
+          path="/dashboard"
+          element={<div data-testid="dashboard-destination" />}
+        />
+      </Routes>,
+      { route: "/event-success/launch-day" },
+    );
+
+  it("shows a loading indicator while the event is being fetched", () => {
+    const single = vi.fn().mockReturnValue(new Promise(() => {}));
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single,
+    } as const;
+
+    supabase.from.mockImplementation(() => query);
+
+    renderPage();
+
+    expect(screen.getByText(TEXT.eventSuccess.loading)).toBeInTheDocument();
+  });
+
+  it("displays the event title and code once the event has loaded", async () => {
+    const single = vi.fn().mockResolvedValue({ data: event, error: null });
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single,
+    } as const;
+
+    supabase.from.mockImplementation(() => query);
+
+    renderPage();
+
+    expect(
+      await screen.findByText(TEXT.eventSuccess.title),
+    ).toBeInTheDocument();
+
+    const expectedCode = eventCodeFromId(eventId);
+    expect(await screen.findByText(expectedCode)).toBeInTheDocument();
+  });
+
+  it("redirects to the dashboard when the event fails to load", async () => {
+    const single = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "not found" } });
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single,
+    } as const;
+
+    supabase.from.mockImplementation(() => query);
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId("dashboard-destination"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/smoke/NotFound.test.tsx
+++ b/src/__tests__/smoke/NotFound.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import NotFound from "@/pages/NotFound";
+import { TEXT } from "@/constants/text";
+
+describe("NotFound smoke", () => {
+  it("renders the 404 title", () => {
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      TEXT.notFound.title,
+    );
+  });
+
+  it("renders the subtitle", () => {
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(TEXT.notFound.subtitle)).toBeInTheDocument();
+  });
+
+  it("renders a link back to the home page", () => {
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: TEXT.notFound.link });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/");
+  });
+});

--- a/src/__tests__/ui/AttendeeList.test.tsx
+++ b/src/__tests__/ui/AttendeeList.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import AttendeeList from "@/pages/event/components/AttendeeList";
+import { TEXT } from "@/constants/text";
+
+const makeAttendee = (
+  overrides?: Partial<Parameters<typeof AttendeeList>[0]["attendees"][number]>,
+) => ({
+  id: "user-1",
+  name: "Alice Smith",
+  headline: "Software Engineer",
+  avatar_url: null,
+  linkedin_id: "alicesmith",
+  ...overrides,
+});
+
+const attendees = [makeAttendee()];
+
+const renderList = (props?: Partial<Parameters<typeof AttendeeList>[0]>) =>
+  render(
+    <AttendeeList
+      attendees={[]}
+      currentUserId={null}
+      isOrganizer={false}
+      isLoading={false}
+      {...props}
+    />,
+  );
+
+describe("AttendeeList", () => {
+  describe("loading state", () => {
+    it("shows the loading message while data is being fetched", () => {
+      renderList({ isLoading: true });
+      expect(
+        screen.getByText(TEXT.event.attendeeList.loading),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows the organizer-specific empty message when there are no attendees", () => {
+      renderList({ isOrganizer: true });
+      expect(
+        screen.getByText(TEXT.event.attendeeList.organizerEmpty),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the attendee-specific empty message for non-organizers", () => {
+      renderList({ isOrganizer: false });
+      expect(
+        screen.getByText(TEXT.event.attendeeList.attendeeEmpty),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("attendee count label", () => {
+    it("uses the singular label for exactly one attendee", () => {
+      renderList({ attendees: [makeAttendee()] });
+      expect(
+        screen.getByText(`1 ${TEXT.event.attendeeList.singular}`, {
+          exact: false,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("uses the plural label for two or more attendees", () => {
+      renderList({
+        attendees: [
+          makeAttendee(),
+          makeAttendee({ id: "user-2", name: "Bob Jones" }),
+        ],
+      });
+      expect(
+        screen.getByText(`2 ${TEXT.event.attendeeList.plural}`, {
+          exact: false,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("uses the plural label for zero attendees", () => {
+      renderList({ attendees: [] });
+      expect(
+        screen.getByText(`0 ${TEXT.event.attendeeList.plural}`, {
+          exact: false,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("attendee row", () => {
+    it("renders the attendee's name", () => {
+      renderList({ attendees });
+      expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    });
+
+    it("renders the attendee's headline when present", () => {
+      renderList({ attendees });
+      expect(screen.getByText("Software Engineer")).toBeInTheDocument();
+    });
+
+    it("does not render a headline element when headline is absent", () => {
+      renderList({ attendees: [makeAttendee({ headline: null })] });
+      expect(screen.queryByText("Software Engineer")).not.toBeInTheDocument();
+    });
+
+    it("shows 'View Your Profile' label for the current user", () => {
+      renderList({ attendees, currentUserId: "user-1" });
+      expect(
+        screen.getByText(TEXT.event.header.viewSelfProfile),
+      ).toBeInTheDocument();
+    });
+
+    it("shows 'View Profile' label for other attendees", () => {
+      renderList({ attendees, currentUserId: "other-user" });
+      expect(
+        screen.getByText(TEXT.event.header.viewProfile),
+      ).toBeInTheDocument();
+    });
+
+    it("renders avatar initials derived from the attendee name", () => {
+      renderList({ attendees });
+      expect(screen.getByText("AS")).toBeInTheDocument();
+    });
+  });
+
+  describe("LinkedIn button", () => {
+    it("opens the LinkedIn profile in a new tab when linkedin_id is set", async () => {
+      const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+      const user = userEvent.setup();
+
+      renderList({ attendees, currentUserId: "other-user" });
+
+      await user.click(screen.getByText(TEXT.event.header.viewProfile));
+
+      expect(openSpy).toHaveBeenCalledWith(
+        "https://www.linkedin.com/in/alicesmith",
+        "_blank",
+      );
+
+      openSpy.mockRestore();
+    });
+
+    it("shows an info toast instead of opening a tab when linkedin_id is missing", async () => {
+      const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+      const user = userEvent.setup();
+
+      renderList({
+        attendees: [makeAttendee({ linkedin_id: null })],
+        currentUserId: "other-user",
+      });
+
+      await user.click(screen.getByText(TEXT.event.header.viewProfile));
+
+      expect(openSpy).not.toHaveBeenCalled();
+
+      openSpy.mockRestore();
+    });
+  });
+});

--- a/src/__tests__/ui/EventHeader.test.tsx
+++ b/src/__tests__/ui/EventHeader.test.tsx
@@ -1,0 +1,306 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import EventHeader from "@/pages/event/components/EventHeader";
+import { TEXT } from "@/constants/text";
+
+const baseEvent = {
+  id: "event-1",
+  slug: "launch-day",
+  name: "Launch Day",
+  organizer_id: "organizer-1",
+  starts_at: "2025-06-15T09:00:00.000Z",
+  ends_at: "2025-06-15T11:00:00.000Z",
+  location: "Gothenburg, Sweden",
+};
+
+const organizer = {
+  id: "organizer-1",
+  name: "Jane Doe",
+  headline: "Event Organizer",
+  avatar_url: null,
+  linkedin_id: "janedoe",
+};
+
+const defaultProps = {
+  event: baseEvent,
+  eventCode: "123456",
+  organizer,
+  currentUserId: null,
+  isOrganizer: false,
+  isAttending: false,
+};
+
+describe("EventHeader", () => {
+  describe("event details", () => {
+    it("renders the event name", () => {
+      render(<EventHeader {...defaultProps} />);
+      expect(screen.getByText("Launch Day")).toBeInTheDocument();
+    });
+
+    it("renders the event code with the label", () => {
+      render(<EventHeader {...defaultProps} />);
+      expect(
+        screen.getByText(`${TEXT.common.labels.eventCode}: 123456`, {
+          exact: false,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the event location", () => {
+      render(<EventHeader {...defaultProps} />);
+      expect(screen.getByText("Gothenburg, Sweden")).toBeInTheDocument();
+    });
+
+    it("does not render a date section when starts_at and ends_at are both absent", () => {
+      render(
+        <EventHeader
+          {...defaultProps}
+          event={{ ...baseEvent, starts_at: null, ends_at: null }}
+        />,
+      );
+      expect(
+        screen.queryByText(TEXT.common.labels.dateNotSet),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render a time section when starts_at and ends_at are both absent", () => {
+      render(
+        <EventHeader
+          {...defaultProps}
+          event={{ ...baseEvent, starts_at: null, ends_at: null }}
+        />,
+      );
+      expect(
+        screen.queryByText(TEXT.common.labels.timeNotSet),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render the location element when location is absent", () => {
+      render(
+        <EventHeader
+          {...defaultProps}
+          event={{ ...baseEvent, location: null }}
+        />,
+      );
+      expect(screen.queryByText("Gothenburg, Sweden")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("organizer section", () => {
+    it("renders the organizer name with the hosted-by prefix", () => {
+      render(<EventHeader {...defaultProps} />);
+      expect(screen.getByText(TEXT.event.header.hostedBy)).toBeInTheDocument();
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    });
+
+    it("renders the organizer headline when present", () => {
+      render(<EventHeader {...defaultProps} />);
+      expect(screen.getByText("Event Organizer")).toBeInTheDocument();
+    });
+
+    it("shows 'View Your Profile' when the current user is the organizer", () => {
+      render(<EventHeader {...defaultProps} currentUserId="organizer-1" />);
+      expect(
+        screen.getByText(TEXT.event.header.viewSelfProfile),
+      ).toBeInTheDocument();
+    });
+
+    it("shows 'View Profile' for other users", () => {
+      render(<EventHeader {...defaultProps} currentUserId="other-user" />);
+      expect(
+        screen.getByText(TEXT.event.header.viewProfile),
+      ).toBeInTheDocument();
+    });
+
+    it("opens the organizer's LinkedIn profile in a new tab", async () => {
+      const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+      const user = userEvent.setup();
+
+      render(<EventHeader {...defaultProps} currentUserId="other-user" />);
+
+      await user.click(screen.getByText(TEXT.event.header.viewProfile));
+
+      expect(openSpy).toHaveBeenCalledWith(
+        "https://www.linkedin.com/in/janedoe",
+        "_blank",
+      );
+
+      openSpy.mockRestore();
+    });
+
+    it("shows an info toast when the organizer has no linkedin_id", async () => {
+      const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+      const user = userEvent.setup();
+
+      render(
+        <EventHeader
+          {...defaultProps}
+          organizer={{ ...organizer, linkedin_id: null }}
+        />,
+      );
+
+      await user.click(screen.getByText(TEXT.event.header.viewProfile));
+
+      expect(openSpy).not.toHaveBeenCalled();
+
+      openSpy.mockRestore();
+    });
+  });
+
+  describe("check-in badge", () => {
+    it("shows the checked-in badge when the user is attending", () => {
+      render(<EventHeader {...defaultProps} isAttending />);
+      expect(
+        screen.getByText(TEXT.event.header.checkedInShort),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the checked-in badge when the user is not attending", () => {
+      render(<EventHeader {...defaultProps} isAttending={false} />);
+      expect(
+        screen.queryByText(TEXT.event.header.checkedInShort),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("organizer controls", () => {
+    it("shows the View QR Code button for organizers when onShowQr is provided", () => {
+      render(<EventHeader {...defaultProps} isOrganizer onShowQr={vi.fn()} />);
+      expect(
+        screen.getByRole("button", { name: TEXT.common.buttons.viewQrCode }),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the View QR Code button for non-organizers", () => {
+      render(
+        <EventHeader
+          {...defaultProps}
+          isOrganizer={false}
+          onShowQr={vi.fn()}
+        />,
+      );
+      expect(
+        screen.queryByRole("button", { name: TEXT.common.buttons.viewQrCode }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the options dropdown trigger for organizers when edit/delete handlers are provided", () => {
+      render(
+        <EventHeader
+          {...defaultProps}
+          isOrganizer
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: TEXT.event.header.options }),
+      ).toBeInTheDocument();
+    });
+
+    it("opens the dropdown and exposes edit and delete items", async () => {
+      const user = userEvent.setup();
+      render(
+        <EventHeader
+          {...defaultProps}
+          isOrganizer
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: TEXT.event.header.options }),
+      );
+
+      expect(
+        await screen.findByText(TEXT.event.header.edit),
+      ).toBeInTheDocument();
+      expect(screen.getByText(TEXT.event.header.delete)).toBeInTheDocument();
+    });
+
+    it("calls onEdit when the Edit item is selected", async () => {
+      const onEdit = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <EventHeader
+          {...defaultProps}
+          isOrganizer
+          onEdit={onEdit}
+          onDelete={vi.fn()}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: TEXT.event.header.options }),
+      );
+      await user.click(await screen.findByText(TEXT.event.header.edit));
+
+      expect(onEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onDelete when the Delete item is selected", async () => {
+      const onDelete = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <EventHeader
+          {...defaultProps}
+          isOrganizer
+          onEdit={vi.fn()}
+          onDelete={onDelete}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: TEXT.event.header.options }),
+      );
+      await user.click(await screen.findByText(TEXT.event.header.delete));
+
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not show the options menu trigger when isOrganizer is false", () => {
+      render(
+        <EventHeader
+          {...defaultProps}
+          isOrganizer={false}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+      expect(
+        screen.queryByRole("button", { name: TEXT.event.header.options }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("compact variant", () => {
+    it("renders the event name in the compact variant", () => {
+      render(<EventHeader {...defaultProps} variant="compact" />);
+      expect(
+        screen.getByRole("heading", { name: "Launch Day" }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the event code in the compact variant", () => {
+      render(<EventHeader {...defaultProps} variant="compact" />);
+      expect(
+        screen.getByText(`${TEXT.common.labels.eventCode}: 123456`, {
+          exact: false,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the organizer name with 'Hosted by' in the compact variant", () => {
+      render(<EventHeader {...defaultProps} variant="compact" />);
+      expect(
+        screen.getByText(`${TEXT.event.header.hostedBy} Jane Doe`, {
+          exact: false,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
@@ -7,6 +7,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./vitest.polyfill.ts", "./vitest.setup.ts"],
     css: true,
+    exclude: [...configDefaults.exclude, "**/e2e/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Grows Vitest test count from 39 to 110. Adds Playwright for e2e browser smoke tests.

## Changes

- **Unit tests** for all four pure functions in `src/lib/events.ts` — including timezone-safe assertions for date functions (noon UTC anchor avoids day-boundary failures across any UTC offset)
- **Component tests** for `EventHeader` (event details, organizer section, checked-in badge, organizer dropdown, compact variant) and `AttendeeList` (loading, empty states, singular/plural count, avatar initials, LinkedIn button)
- **Smoke tests** for `NotFound` (404 heading, home link) and `EventSuccess` (loading skeleton, event code display, dashboard redirect on error)
- **Playwright setup** — Chromium only, targets Vite dev server on port 8080; covers landing page, auth page, and 404 page
- `vitest.config.ts` updated to exclude `e2e/**` so Playwright specs are not picked up by Vitest

## Notes

The original Copilot-generated branch (`copilot/analyze-test-coverage`) had timezone-dependent test assertions that passed on CI (UTC) but failed locally. Fixed by using noon-UTC timestamps for `parseEventDateParts` and a round-trip assertion for `combineEventDateAndTime`.

Generated with Claude Code