### PR TITLE
chore: update robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,14 +1,7 @@
-User-agent: Googlebot
-Allow: /
-
-User-agent: Bingbot
-Allow: /
-
-User-agent: Twitterbot
-Allow: /
-
-User-agent: facebookexternalhit
-Allow: /
-
 User-agent: *
+Disallow: /auth/
+Disallow: /auth-callback/
+Disallow: /dashboard/
+Disallow: /create-event/
+Disallow: /join-event/
 Allow: /


### PR DESCRIPTION
Restricts search engine indexing for internal and authenticated routes (/auth, /dashboard, etc.) while keeping landing and public event pages visible.