### PR TITLE
[feature] Real-time Attendee Updates

### DIFF
--- a/src/hooks/useAttendances.ts
+++ b/src/hooks/useAttendances.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
@@ -81,6 +82,36 @@ export const useAttendances = (options: UseAttendancesOptions) => {
     enabled,
     queryFn: () => fetchAttendances(options),
   });
+};
+
+export const useRealtimeAttendances = (eventId?: string) => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!eventId) return;
+
+    const channel = supabase
+      .channel(`attendances:event_id=eq.${eventId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "attendances",
+          filter: `event_id=eq.${eventId}`,
+        },
+        () => {
+          queryClient.invalidateQueries({
+            queryKey: ["attendances", { eventId }],
+          });
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [eventId, queryClient]);
 };
 
 export const useUpcoming = (

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -23,7 +23,11 @@ import EventHeader from "@/pages/event/components/EventHeader";
 import AttendButton from "@/pages/event/components/AttendButton";
 import AttendeeList from "@/pages/event/components/AttendeeList";
 import { useEvent, useDeleteEvent } from "@/hooks/useEvents";
-import { useAttendances, useJoinEvent } from "@/hooks/useAttendances";
+import {
+  useAttendances,
+  useJoinEvent,
+  useRealtimeAttendances,
+} from "@/hooks/useAttendances";
 import { useMyProfile, type ProfileRow } from "@/hooks/useProfile";
 import { TEXT } from "@/constants/text";
 import { eventCodeFromId } from "@/lib/events";
@@ -90,6 +94,8 @@ const EventPage = () => {
     isLoading: isEventLoading,
     error: eventError,
   } = useEvent(eventIdentifier);
+
+  useRealtimeAttendances(event?.id);
 
   useEffect(() => {
     if (eventError) {

--- a/src/test-utils/supabase.ts
+++ b/src/test-utils/supabase.ts
@@ -57,6 +57,16 @@ export const createQueryStub = (overrides?: QueryOverrides): QueryStub => {
   return query;
 };
 
+const makeChannelStub = () => {
+  const channelStub = {
+    on: vi.fn(),
+    subscribe: vi.fn(),
+  };
+  channelStub.on.mockReturnValue(channelStub);
+  channelStub.subscribe.mockReturnValue(channelStub);
+  return channelStub;
+};
+
 export const supabaseStub = {
   auth: {
     getUser: vi.fn(),
@@ -68,6 +78,8 @@ export const supabaseStub = {
       .mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
   },
   from: vi.fn(),
+  channel: vi.fn().mockImplementation(() => makeChannelStub()),
+  removeChannel: vi.fn().mockResolvedValue(undefined),
 };
 
 export const resetSupabaseStub = () => {
@@ -77,6 +89,10 @@ export const resetSupabaseStub = () => {
   supabaseStub.auth.signOut.mockReset();
   supabaseStub.auth.onAuthStateChange.mockReset();
   supabaseStub.from.mockReset();
+  supabaseStub.channel.mockReset();
+  supabaseStub.channel.mockImplementation(() => makeChannelStub());
+  supabaseStub.removeChannel.mockReset();
+  supabaseStub.removeChannel.mockResolvedValue(undefined);
 
   supabaseStub.auth.getUser.mockResolvedValue({
     data: { user: { id: "user_test" } },


### PR DESCRIPTION
## Summary
Makes the attendee list on the Event page update in real-time using Supabase Postgres changes.

## Changes
- Introduced `useRealtimeAttendances` hook to manage subscriptions.
- Connected the hook to `EventPage` to keep the attendee list current without refreshes.

## Notes
Ensures Organizers can see check-ins as they happen live.