### PR TITLE
[fix] Remove lovable-tagger from vite.config (production build broken)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -11,9 +10,7 @@ export default defineConfig(({ mode }) => ({
     allowedHosts: [".ngrok-free.app"],
     hmr: { clientPort: 443 },
   },
-  plugins: [react(), mode === "development" && componentTagger()].filter(
-    Boolean,
-  ),
+  plugins: [react()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
@@ -23,14 +20,5 @@ export default defineConfig(({ mode }) => ({
     target: "es2020",
     sourcemap: mode === "development" ? "hidden" : false,
     minify: "terser",
-    // Raised from Vite's default (500KB) to accommodate the recharts chunk
-    chunkSizeWarningLimit: 900,
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          recharts: ["recharts"],
-        },
-      },
-    },
   },
 }));


### PR DESCRIPTION
## Summary

- Remove `lovable-tagger` import from `vite.config.ts` — package was removed from `package.json` in PR #89 but the config was not updated
- Remove `recharts` from `manualChunks` — also removed from `package.json`
- This caused `ERR_MODULE_NOT_FOUND` on every Vercel production build after #88 merged

## Test plan
- [ ] `npm ci && npm run build` passes locally
- [ ] Vercel deployment goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)