### PR TITLE
[fix] Add missing Textarea component (production build broken)

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };


### PR DESCRIPTION
## What

Restores `src/components/ui/textarea.tsx` which was accidentally dropped when `feature/feedback-loop` was rebased from a stale local branch and force-pushed. The file is imported by `FeedbackDialog.tsx`, causing the production Vite build to fail with:

```
Could not load src/components/ui/textarea: ENOENT
```

## Why it matters

Production has been broken since PR #97 merged. This is a straight restore of the file from the lost commit (`0a5c6df`).