### PR TITLE
[fix] Fix production URL fallback (was pointing at stale Lovable URL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,9 @@ VITE_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 
 # Application configuration
 # The public URL of the application (e.g. https://linkback.com)
-# Used for QR code generation and OAuth redirects
+# Used for QR code generation and OAuth redirects.
+# Set this in Vercel → Project Settings → Environment Variables (Production scope).
+# Example production value: VITE_PUBLIC_URL=https://linked-list-harry-denells-projects.vercel.app
 VITE_PUBLIC_URL=
 
 # MCP server configuration (optional, for Claude Code extensions)

--- a/src/__tests__/lib/urls.test.ts
+++ b/src/__tests__/lib/urls.test.ts
@@ -42,5 +42,11 @@ describe("URL Helpers", () => {
       vi.stubEnv("VITE_PUBLIC_URL", "https://prod.linkback.com/");
       expect(getProductionUrl()).toBe("https://prod.linkback.com");
     });
+
+    it("should fall back to the correct production domain when VITE_PUBLIC_URL is unset", () => {
+      expect(getProductionUrl()).toBe(
+        "https://linked-list-harry-denells-projects.vercel.app",
+      );
+    });
   });
 });

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -22,6 +22,7 @@ export const getEventUrl = (slug: string) => {
  */
 export const getProductionUrl = () => {
   const url =
-    import.meta.env.VITE_PUBLIC_URL || "https://linked-list-nine.vercel.app";
+    import.meta.env.VITE_PUBLIC_URL ||
+    "https://linked-list-harry-denells-projects.vercel.app";
   return url.replace(/\/$/, "");
 };

--- a/supabase/functions/send-event-confirmation/index.ts
+++ b/supabase/functions/send-event-confirmation/index.ts
@@ -7,7 +7,8 @@ const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 const EMAIL_FROM =
   Deno.env.get("EMAIL_FROM") ?? "LinkBack <events@updates.linkback.com>";
 const APP_URL =
-  Deno.env.get("APP_URL") ?? "https://linked-list-nine.vercel.app";
+  Deno.env.get("APP_URL") ??
+  "https://linked-list-harry-denells-projects.vercel.app";
 
 const escapeHtml = (str: string): string =>
   str


### PR DESCRIPTION
## What

The hardcoded fallback in `getProductionUrl()` was `linked-list-nine.vercel.app` — a Lovable-platform URL that doesn't exist in this Vercel account and is likely a stale snapshot from before the repo was migrated to GitHub.

The correct production domain is `linked-list-harry-denells-projects.vercel.app`.

## Changes

- `src/lib/urls.ts` — update fallback in `getProductionUrl()`
- `.env.example` — document the correct `VITE_PUBLIC_URL` value

## Still needed (manual Vercel config)

For QR codes to reliably use the production URL regardless of which preview URL the organizer is viewing on:

1. **Vercel → Project Settings → Environment Variables** — add `VITE_PUBLIC_URL=https://linked-list-harry-denells-projects.vercel.app` scoped to Production
2. **Vercel → Project Settings → Deployment Protection** — disable or set to "Only Preview Deployments" to stop Vercel intercepting QR code scans from external devices