### PR TITLE
[chore] Fix hardcoded production fallback URLs

### DIFF
--- a/src/__tests__/lib/urls.test.ts
+++ b/src/__tests__/lib/urls.test.ts
@@ -49,9 +49,13 @@ describe("URL Helpers", () => {
       expect(getProductionUrl()).toBe("https://prod.linkback.com");
     });
 
-    it("should fall back to the correct production domain when VITE_PUBLIC_URL is unset", () => {
-      expect(getProductionUrl()).toBe(
-        "https://linked-list-harry-denells-projects.vercel.app",
+    it("should fall back to localhost in development when VITE_PUBLIC_URL is unset", () => {
+      expect(getProductionUrl(false)).toBe("http://localhost:8080");
+    });
+
+    it("should throw an error in production when VITE_PUBLIC_URL is unset", () => {
+      expect(() => getProductionUrl(true)).toThrow(
+        "VITE_PUBLIC_URL environment variable is required in production",
       );
     });
   });

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -34,7 +34,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,25 +1,9 @@
 class Analytics {
-  private isProduction = import.meta.env.PROD;
+  identify(_userId: string, _traits?: Record<string, unknown>) {}
 
-  identify(userId: string, traits?: Record<string, unknown>) {
-    if (!this.isProduction) {
-      console.log(`[Analytics] Identify User: ${userId}`, traits || "");
-    }
-    // TODO: mixpanel.identify(userId) or posthog.identify(userId)
-  }
+  track(_eventName: string, _properties?: Record<string, unknown>) {}
 
-  track(eventName: string, properties?: Record<string, unknown>) {
-    if (!this.isProduction) {
-      console.log(`[Analytics] Track Event: ${eventName}`, properties || "");
-    }
-    // TODO: mixpanel.track(eventName, properties) or posthog.capture(eventName, properties)
-  }
-
-  page(pageName: string, properties?: Record<string, unknown>) {
-    if (!this.isProduction) {
-      console.log(`[Analytics] Page View: ${pageName}`, properties || "");
-    }
-  }
+  page(_pageName: string, _properties?: Record<string, unknown>) {}
 }
 
 export const analytics = new Analytics();

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,9 +1,25 @@
 class Analytics {
-  identify(_userId: string, _traits?: Record<string, unknown>) {}
+  private isProduction = import.meta.env.PROD;
 
-  track(_eventName: string, _properties?: Record<string, unknown>) {}
+  identify(userId: string, traits?: Record<string, unknown>) {
+    if (!this.isProduction) {
+      console.log(`[Analytics] Identify User: ${userId}`, traits || "");
+    }
+    // TODO: mixpanel.identify(userId) or posthog.identify(userId)
+  }
 
-  page(_pageName: string, _properties?: Record<string, unknown>) {}
+  track(eventName: string, properties?: Record<string, unknown>) {
+    if (!this.isProduction) {
+      console.log(`[Analytics] Track Event: ${eventName}`, properties || "");
+    }
+    // TODO: mixpanel.track(eventName, properties) or posthog.capture(eventName, properties)
+  }
+
+  page(pageName: string, properties?: Record<string, unknown>) {
+    if (!this.isProduction) {
+      console.log(`[Analytics] Page View: ${pageName}`, properties || "");
+    }
+  }
 }
 
 export const analytics = new Analytics();

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -20,9 +20,17 @@ export const getEventUrl = (slug: string) => {
  * Returns the stable production URL.
  * Used for OAuth redirects since LinkedIn requires a pre-registered stable domain.
  */
-export const getProductionUrl = () => {
-  const url =
-    import.meta.env.VITE_PUBLIC_URL ||
-    "https://linked-list-harry-denells-projects.vercel.app";
+export const getProductionUrl = (isProd = import.meta.env.PROD) => {
+  const url = import.meta.env.VITE_PUBLIC_URL;
+
+  if (!url) {
+    if (isProd) {
+      throw new Error(
+        "VITE_PUBLIC_URL environment variable is required in production",
+      );
+    }
+    return "http://localhost:8080";
+  }
+
   return url.replace(/\/$/, "");
 };

--- a/supabase/functions/send-event-confirmation/README.md
+++ b/supabase/functions/send-event-confirmation/README.md
@@ -5,9 +5,11 @@ This Edge Function sends a confirmation email to the event organizer whenever a 
 ## Setup
 
 1. **Get a Resend API Key:** Sign up at [resend.com](https://resend.com).
-2. **Add Secret to Supabase:**
+2. **Add Secrets to Supabase:**
    ```bash
    supabase secrets set RESEND_API_KEY=your_key_here
+   supabase secrets set APP_URL=https://your-production-app.com
+   supabase secrets set EMAIL_FROM="Your App <events@updates.your-app.com>"
    ```
 3. **Configure database settings** (run once per environment in the Supabase SQL editor):
    ```sql

--- a/supabase/functions/send-event-confirmation/index.ts
+++ b/supabase/functions/send-event-confirmation/index.ts
@@ -6,9 +6,7 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 const EMAIL_FROM =
   Deno.env.get("EMAIL_FROM") ?? "LinkBack <events@updates.linkback.com>";
-const APP_URL =
-  Deno.env.get("APP_URL") ??
-  "https://linked-list-harry-denells-projects.vercel.app";
+const APP_URL = Deno.env.get("APP_URL")?.replace(/\/+$/, "");
 
 const escapeHtml = (str: string): string =>
   str
@@ -40,6 +38,13 @@ serve(async (req) => {
   if (!SUPABASE_URL) {
     return new Response(
       JSON.stringify({ error: "SUPABASE_URL is not configured" }),
+      { headers: { "Content-Type": "application/json" }, status: 500 },
+    );
+  }
+
+  if (!APP_URL) {
+    return new Response(
+      JSON.stringify({ error: "APP_URL is not configured" }),
       { headers: { "Content-Type": "application/json" }, status: 500 },
     );
   }


### PR DESCRIPTION
## Summary
Removes hardcoded fallback URLs that point to developer-specific environments, ensuring production stability and environment independence.

## Changes
- Updated `src/lib/urls.ts` to throw an error in production if `VITE_PUBLIC_URL` is missing.
- Removed hardcoded fallback from `getProductionUrl`, defaulting to localhost in development.
- Updated Supabase `send-event-confirmation` Edge Function to require `APP_URL` and return a 500 error if unconfigured.
- Added and updated tests in `src/__tests__/lib/urls.test.ts` to verify environment-aware logic.

## Notes
This removes 'poison pills' that would have caused production emails and OAuth redirects to point to the wrong Vercel project.