### PR TITLE
[chore] Harden AI review guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Always use `.github/pull_request_template.md`. When using `gh pr create`, do not
 
 - Merge commits only (no squash, no rebase merge)
 - 1 approving review required
-- **Wait for Copilot Review:** Do not merge until Copilot has finished its review and all findings are addressed.
+- **Wait for Copilot Review:** Do not merge until Copilot has finished its review and all findings are addressed. You MUST reply to **every individual comment thread** directly; top-level summary comments are strictly prohibited.
 - **No Admin Merge:** Do not use admin privileges to bypass CI or review requirements unless explicitly instructed by the user.
 - All conversations must be resolved
 - All required checks must pass (test, check-fixup)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ This project utilizes AI-powered code reviews (e.g., GitHub Copilot) to maintain
 
 1. **Wait for AI Review:** After opening a PR, wait for the AI reviewer to post its initial feedback.
 2. **Review & Take a Stance:** Thoroughly evaluate every comment. Do not blindly apply changes, but do not ignore them without a technical rationale.
-3. **Reply & Close the Loop:** For every comment thread:
+3. **Reply & Close the Loop:** You MUST reply to **every individual comment thread** directly. A single top-level summary comment is strictly prohibited. For every comment thread:
    - If you apply the change: Reply explaining that it has been fixed.
    - If you disagree or the suggestion is incorrect: Reply with a technical explanation of why the current implementation is preferred.
 4. **Iterative Refinement:** If feedback requires code changes during review, push follow-up commits as needed. If you need to clean up the PR branch history, do so with amend/autosquash before requesting final approval. This refers to rewriting the PR branch history, not using GitHub's squash-merge.


### PR DESCRIPTION
## Summary
Hardens the AI review guidelines in both human-facing (`CONTRIBUTING.md`) and agent-facing (`CLAUDE.md`) documentation to ensure all review feedback is addressed correctly.

## Changes
- Updated `CONTRIBUTING.md` to explicitly mandate replies to **every individual comment thread**.
- Updated `CLAUDE.md` to prohibit top-level summary comments as a substitute for threaded replies.

## Notes
This change ensures that every piece of feedback from Copilot (or other AI reviewers) is acknowledged and resolved in its own context, preventing oversight and closing the loop definitively.