### PR TITLE
[CRITICAL] The 'Midnight Boundary' Bug (Event Creation)

### DIFF
--- a/src/__tests__/smoke/CreateEventForm.test.tsx
+++ b/src/__tests__/smoke/CreateEventForm.test.tsx
@@ -108,4 +108,30 @@ describe("CreateEvent smoke", () => {
       await screen.findByText(TEXT.createEvent.toast.invalidTimeRange),
     ).toBeInTheDocument();
   });
+
+  it("allows events to run past midnight (Midnight Boundary Bug)", async () => {
+    const user = userEvent.setup();
+    renderCreateEvent();
+
+    await user.type(screen.getByLabelText(/event name/i), "Late Night Party");
+    await user.type(screen.getByLabelText(/location/i), "Gothenburg, Sweden");
+    await user.type(screen.getByLabelText(/event date/i), "2025-05-10");
+    await user.type(screen.getByLabelText(/start time/i), "22:00");
+    await user.type(screen.getByLabelText(/end time/i), "02:00");
+
+    await user.click(
+      screen.getByRole("button", {
+        name: new RegExp(TEXT.createEvent.form.submitIdle, "i"),
+      }),
+    );
+
+    // This should NOT show an invalid time range toast
+    expect(
+      screen.queryByText(TEXT.createEvent.toast.invalidTimeRange),
+    ).not.toBeInTheDocument();
+
+    expect(
+      await screen.findByText(TEXT.createEvent.toast.success),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/pages/CreateEvent.tsx
+++ b/src/pages/CreateEvent.tsx
@@ -111,7 +111,7 @@ const CreateEvent = () => {
         values.eventDate,
         values.startTime,
       );
-      const normalizedEndsAt = combineEventDateAndTime(
+      let normalizedEndsAt = combineEventDateAndTime(
         values.eventDate,
         values.endTime,
       );
@@ -122,6 +122,13 @@ const CreateEvent = () => {
           description: TEXT.createEvent.toast.missingDateTime,
         });
         return;
+      }
+
+      // If end time is earlier than start time, it means the event ends the next day
+      if (normalizedEndsAt <= normalizedStartsAt) {
+        const endDate = new Date(normalizedEndsAt);
+        endDate.setDate(endDate.getDate() + 1);
+        normalizedEndsAt = endDate.toISOString();
       }
 
       if (isEditing && editingEventId) {

--- a/src/pages/create-event/schema.ts
+++ b/src/pages/create-event/schema.ts
@@ -13,9 +13,7 @@ export const createEventSchema = z
   .refine(
     (data) => {
       if (!data.eventDate || !data.startTime || !data.endTime) return true;
-      const start = new Date(`${data.eventDate}T${data.startTime}`);
-      const end = new Date(`${data.eventDate}T${data.endTime}`);
-      return end > start;
+      return data.startTime !== data.endTime;
     },
     {
       message: TEXT.createEvent.toast.invalidTimeRange,


### PR DESCRIPTION
Fixes #145

**Description:**
The event creation form does not allow an event to run past midnight (e.g., start 20:50, end 00:49). System assumed end time is earlier than start time on the same day due to lack of an 'End Date' field.

**Fix:**
- Updated `createEventSchema` to only check that start and end times are not identical.
- Updated `CreateEvent.tsx` `onSubmit` to add 24 hours to `normalizedEndsAt` if it is less than or equal to `normalizedStartsAt`.
- Added test coverage in `CreateEventForm.test.tsx`.