### PR TITLE
[MINOR] Empty State Actions

### DIFF
--- a/src/__tests__/smoke/EventPage.test.tsx
+++ b/src/__tests__/smoke/EventPage.test.tsx
@@ -3,6 +3,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { createQueryStub } from "@/test-utils/supabase";
 import { Route, Routes } from "react-router-dom";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import EventPage from "@/pages/EventPage";
 import { TEXT } from "@/constants/text";
@@ -31,5 +32,69 @@ describe("EventPage states", () => {
         content.includes(TEXT.event.page.notFoundDescription),
       ),
     ).toBeInTheDocument();
+  });
+
+  it("does not show the 'Export CSV' option when there are zero attendees", async () => {
+    const user = userEvent.setup();
+
+    // Mock session for organizer
+    vi.mocked(supabase.auth.getSession).mockResolvedValue({
+      data: { session: { user: { id: "user-1" } } as any },
+      error: null,
+    });
+
+    // Mock event data
+    const eventQuery = createQueryStub({
+      singleResult: {
+        data: {
+          id: "event-1",
+          slug: "test-event",
+          name: "Test Event",
+          organizer_id: "user-1",
+          starts_at: new Date().toISOString(),
+          ends_at: new Date().toISOString(),
+          location: "Test Location",
+        },
+        error: null,
+      },
+    });
+
+    // Mock attendance data (zero attendees)
+    const attendanceQuery = createQueryStub({
+      multipleResult: { data: [], error: null },
+    });
+
+    // Mock profiles data
+    const profileQuery = createQueryStub({
+      singleResult: { data: { name: "Test Organizer" }, error: null },
+    });
+
+    vi.mocked(supabase.from).mockImplementation((table: any) => {
+      if (table === "events") return eventQuery;
+      if (table === "attendances") return attendanceQuery;
+      if (table === "profiles") return profileQuery;
+      return createQueryStub({});
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/event/:slug" element={<EventPage />} />
+      </Routes>,
+      { route: "/event/test-event" },
+    );
+
+    // Wait for event to load
+    await screen.findByText("Test Event");
+
+    // Open the dropdown menu
+    const optionsButton = await screen.findByRole("button", {
+      name: TEXT.event.header.options,
+    });
+    await user.click(optionsButton);
+
+    // Verify 'Export CSV' is NOT in the document
+    expect(
+      screen.queryByText(TEXT.event.attendeeList.exportCsv),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -383,10 +383,12 @@ const EventPage = () => {
                   <QrCode className="mr-2 h-4 w-4" aria-hidden="true" />
                   {TEXT.common.buttons.viewQrCode}
                 </DropdownMenuItem>
-                <DropdownMenuItem onSelect={handleExport}>
-                  <Download className="mr-2 h-4 w-4" aria-hidden="true" />
-                  {TEXT.event.attendeeList.exportCsv}
-                </DropdownMenuItem>
+                {(attendeeRecords?.length ?? 0) > 0 && (
+                  <DropdownMenuItem onSelect={handleExport}>
+                    <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+                    {TEXT.event.attendeeList.exportCsv}
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onSelect={() =>


### PR DESCRIPTION
Fixes #158

**Description:**
System allows exporting an 'Attendee CSV' even when zero people have checked in.

**Fix:**
- Updated `EventPage.tsx` to hide the 'Export CSV' `DropdownMenuItem` if the attendee count is 0.
- Added test coverage in `EventPage.test.tsx` to verify this behavior.