### PR TITLE
[MAJOR] Dashboard Counter Mismatch

### DIFF
--- a/src/__tests__/routes/Dashboard.test.tsx
+++ b/src/__tests__/routes/Dashboard.test.tsx
@@ -1,0 +1,59 @@
+import { renderWithProviders } from "@/test-utils/render";
+import { supabase } from "@/integrations/supabase/client";
+import { createQueryStub } from "@/test-utils/supabase";
+import { Route, Routes } from "react-router-dom";
+import { screen } from "@testing-library/react";
+import { vi } from "vitest";
+import Dashboard from "@/pages/Dashboard";
+
+describe("Dashboard", () => {
+  it("displays correct counts for hosted events", async () => {
+    vi.mocked(supabase.auth.getSession).mockResolvedValue({
+      data: { session: { user: { id: "user-1" } } as any },
+      error: null,
+    });
+
+    const now = Date.now();
+    const futureDate = new Date(now + 86400000).toISOString(); // +1 day
+    const pastDate = new Date(now - 86400000).toISOString(); // -1 day
+
+    vi.mocked(supabase.from).mockImplementation((table: any) => {
+      if (table === "events") {
+        return createQueryStub({
+          baseResult: {
+            data: [
+              {
+                id: "event-1",
+                name: "Future Event",
+                starts_at: futureDate,
+                organizer_id: "user-1",
+              },
+              {
+                id: "event-2",
+                name: "Past Event",
+                starts_at: pastDate,
+                organizer_id: "user-1",
+              }
+            ],
+            error: null,
+          }
+        });
+      }
+      return createQueryStub({});
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>,
+      { route: "/dashboard" }
+    );
+
+    // Wait for it to load
+    expect(await screen.findByText("2 events hosted · 0 attended")).toBeInTheDocument();
+
+    // Check tabs
+    expect(screen.getByText("Future Event")).toBeInTheDocument();
+    expect(screen.queryByText("Past Event")).not.toBeInTheDocument();
+  });
+});

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -261,6 +261,7 @@ export const useDeleteEvent = () => {
       }
 
       await queryClient.invalidateQueries({ queryKey: ["attendances"] });
+      await queryClient.invalidateQueries({ queryKey: ["upcoming-events"] });
     },
   });
 };

--- a/src/pages/dashboard/components/MyEventsList.tsx
+++ b/src/pages/dashboard/components/MyEventsList.tsx
@@ -85,7 +85,11 @@ const MyEventsList = ({
         </div>
       ) : events.length === 0 ? (
         <div className="bg-bg-base border border-border-subtle rounded-xl p-8 text-center">
-          <p className="text-sm text-text-secondary mb-4">No events found.</p>
+          <p className="text-sm text-text-secondary mb-4">
+            {title === "My events" || title === "Upcoming"
+              ? "No upcoming events found."
+              : "No past events found."}
+          </p>
           <Link to="/create-event" state={{ fromDashboard: true }}>
             <Button variant="primary" size="sm">
               Create event


### PR DESCRIPTION
Fixes #150

**Description:**
After deleting an event, the top stats say '7 events hosted' while the list below says 'No events found'.

**Fix:**
- Updated `MyEventsList.tsx` to show context-aware empty state text (e.g. 'No upcoming events found').
- Updated `useEvents.ts` to invalidate the `upcoming-events` query on event deletion to ensure dashboard counters are perfectly synchronized.
- Added `Dashboard.test.tsx` to verify dashboard routing and rendering.