### PR TITLE
[feature/phantom-flash-152] Prevent auth screen flash

### DIFF
--- a/src/__tests__/auth/AuthLoading.test.tsx
+++ b/src/__tests__/auth/AuthLoading.test.tsx
@@ -1,0 +1,59 @@
+import { renderWithProviders } from "@/test-utils/render";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { supabase } from "@/integrations/supabase/client";
+import Auth from "@/pages/Auth";
+import type { Mock } from "vitest";
+import { describe, expect, it } from "vitest";
+
+const getSessionMock = supabase.auth.getSession as unknown as Mock;
+
+describe("Auth loading", () => {
+  it("shows a loading state before the session check finishes", async () => {
+    let resolveSession:
+      | ((value: { data: { session: null }; error: null }) => void)
+      | undefined;
+
+    getSessionMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSession = resolve;
+      }),
+    );
+
+    renderWithProviders(<Auth />, { route: "/auth" });
+
+    expect(screen.getByText(/Loading sign in/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Sign in with LinkedIn/i }),
+    ).not.toBeInTheDocument();
+
+    resolveSession?.({ data: { session: null }, error: null });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Sign in with LinkedIn/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("hides the auth card while LinkedIn redirect is pending", async () => {
+    const user = userEvent.setup();
+
+    getSessionMock.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    supabase.auth.signInWithOAuth.mockReturnValueOnce(new Promise(() => {}));
+
+    renderWithProviders(<Auth />, { route: "/auth" });
+
+    await user.click(
+      await screen.findByRole("button", { name: /Sign in with LinkedIn/i }),
+    );
+
+    expect(screen.getByText(/Redirecting to LinkedIn/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Enter event code/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/auth/AuthRedirectFlow.test.tsx
+++ b/src/__tests__/auth/AuthRedirectFlow.test.tsx
@@ -65,7 +65,7 @@ describe("Auth redirect flow", () => {
     });
 
     await user.click(
-      screen.getByRole("button", {
+      await screen.findByRole("button", {
         name: new RegExp(TEXT.auth.card.buttonIdle, "i"),
       }),
     );
@@ -92,7 +92,7 @@ describe("Auth redirect flow", () => {
     });
 
     await user.click(
-      screen.getByRole("button", {
+      await screen.findByRole("button", {
         name: new RegExp(TEXT.auth.card.buttonIdle, "i"),
       }),
     );

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -12,6 +12,7 @@ import { getBaseUrl } from "@/lib/urls";
 const Auth = () => {
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
+  const [isSessionLoading, setIsSessionLoading] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -27,12 +28,47 @@ const Auth = () => {
   }, [location.search]);
 
   useEffect(() => {
-    void supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session) {
-        navigate(redirectPath, { replace: true });
-      }
-    });
+    let isActive = true;
+
+    void supabase.auth
+      .getSession()
+      .then(({ data: { session } }) => {
+        if (!isActive) {
+          return;
+        }
+
+        if (session) {
+          navigate(redirectPath, { replace: true });
+          return;
+        }
+
+        setIsSessionLoading(false);
+      })
+      .catch(() => {
+        if (isActive) {
+          setIsSessionLoading(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
   }, [navigate, redirectPath]);
+
+  if (isSessionLoading || isLoading) {
+    return (
+      <div className="min-h-screen bg-bg-base flex items-center justify-center px-5">
+        <div className="text-center">
+          <div className="w-12 h-0.5 bg-border-subtle rounded-full overflow-hidden mx-auto mb-4 relative">
+            <div className="absolute inset-0 bg-text-primary animate-loader-slide" />
+          </div>
+          <p className="text-[13px] text-text-secondary">
+            {isLoading ? "Redirecting to LinkedIn..." : "Loading sign in..."}
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   const handleLinkedInSignIn = async () => {
     setIsLoading(true);

--- a/src/pages/landing/components/HeroSection.tsx
+++ b/src/pages/landing/components/HeroSection.tsx
@@ -49,11 +49,11 @@ const HeroSection = ({ isAuthenticated }: HeroSectionProps) => {
             variant={isAuthenticated ? "primary" : "linkedin"}
             size="lg"
             className="gap-2"
-            iconRight={<ArrowRight className="h-4 w-4" />}
           >
             {isAuthenticated
               ? "Create your first event"
               : "Sign in with LinkedIn"}
+            <ArrowRight className="h-4 w-4" />
           </Button>
         </Link>
         <Link to="/join-event">


### PR DESCRIPTION
## Summary

Fix the brief Join Event flash that appeared during LinkedIn sign-in.

## Changes

- Add an auth loading shell until the initial session check completes.
- Hide the auth card while the LinkedIn redirect is pending.
- Add regression coverage for the loading and redirect states.

## Notes

- `npm run typecheck` passed.
- `npm run test` passed.
- `npm run build` passed.
- `npm run lint` reported existing warnings but no errors.