### PR TITLE
[feature/join-event-back-button] Fix Join Event back-button logic

### DIFF
--- a/src/__tests__/routes/JoinEvent.navigation.test.tsx
+++ b/src/__tests__/routes/JoinEvent.navigation.test.tsx
@@ -1,0 +1,60 @@
+import { renderWithProviders } from "@/test-utils/render";
+import { screen } from "@testing-library/react";
+import { Route, Routes } from "react-router-dom";
+import JoinEvent from "@/pages/JoinEvent";
+import { TEXT } from "@/constants/text";
+
+describe("JoinEvent navigation", () => {
+  it("defaults to 'Back to Home' when no state is provided", () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/join-event" element={<JoinEvent />} />
+        <Route path="/" element={<div>Home</div>} />
+      </Routes>,
+      { route: "/join-event" },
+    );
+
+    const backLink = screen.getByRole("link", {
+      name: new RegExp(TEXT.common.links.backToHome, "i"),
+    });
+    expect(backLink).toHaveAttribute("href", "/");
+  });
+
+  it("shows 'Back to Dashboard' when coming from dashboard", () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/join-event" element={<JoinEvent />} />
+        <Route path="/dashboard" element={<div>Dashboard</div>} />
+      </Routes>,
+      {
+        initialEntries: [
+          { pathname: "/join-event", state: { fromDashboard: true } },
+        ],
+      },
+    );
+
+    const backLink = screen.getByRole("link", {
+      name: new RegExp(TEXT.common.links.backToDashboard, "i"),
+    });
+    expect(backLink).toHaveAttribute("href", "/dashboard");
+  });
+
+  it("shows 'Back to Sign In' when coming from auth", () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/join-event" element={<JoinEvent />} />
+        <Route path="/auth" element={<div>Auth</div>} />
+      </Routes>,
+      {
+        initialEntries: [
+          { pathname: "/join-event", state: { fromAuth: true } },
+        ],
+      },
+    );
+
+    const backLink = screen.getByRole("link", {
+      name: new RegExp(TEXT.common.links.backToSignIn, "i"),
+    });
+    expect(backLink).toHaveAttribute("href", "/auth");
+  });
+});

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -31,6 +31,7 @@ export const TEXT = {
     links: {
       backToDashboard: "Back to Dashboard",
       backToHome: "Back to Home",
+      backToSignIn: "Back to Sign In",
       viewPastEvents: "View past events",
       returnHome: "Return Home",
       backToHomeArrow: "← Back to home",

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -213,7 +213,7 @@ const Auth = () => {
             <div className="flex-1 h-px bg-border-subtle" />
           </div>
 
-          <Link to="/join-event">
+          <Link to="/join-event" state={{ fromAuth: true }}>
             <Button variant="outline" size="lg" className="w-full">
               Enter event code
             </Button>

--- a/src/pages/JoinEvent.tsx
+++ b/src/pages/JoinEvent.tsx
@@ -31,10 +31,14 @@ const JoinEvent = () => {
   const queryClient = useQueryClient();
 
   const fromDashboard = location.state?.fromDashboard;
-  const backPath = fromDashboard ? "/dashboard" : "/";
+  const fromAuth = location.state?.fromAuth;
+
+  const backPath = fromDashboard ? "/dashboard" : fromAuth ? "/auth" : "/";
   const backText = fromDashboard
     ? TEXT.common.links.backToDashboard
-    : TEXT.common.links.backToHome;
+    : fromAuth
+      ? TEXT.common.links.backToSignIn
+      : TEXT.common.links.backToHome;
 
   const getAuthenticatedUserId = async () => {
     const {


### PR DESCRIPTION
Fixes #175

Changes:
- Add `backToSignIn` to `TEXT.common.links`.
- Pass `fromAuth: true` state when navigating from Auth modal to Join Event page.
- Update `JoinEvent.tsx` to use `fromAuth` state for navigation and labels.
- Add regression test in `src/__tests__/routes/JoinEvent.navigation.test.tsx`.