### PR TITLE
[feature/event-name-breadcrumbs-157] Show human-readable event names in breadcrumbs

### DIFF
--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -251,6 +251,7 @@ export const TEXT = {
     },
   },
   event: {
+    breadcrumb: "Event",
     header: {
       hostedBy: "Hosted by",
       viewProfile: "View Profile",

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -345,7 +345,7 @@ const EventPage = () => {
           </Button>
         </Link>
         <div className="flex-1 text-[12px] font-mono text-text-secondary tracking-[0.5px] uppercase truncate">
-          EVENT · {event.slug?.toUpperCase()}
+          {TEXT.event.breadcrumb} · {event.name.toUpperCase()}
         </div>
         <div className="flex items-center gap-1.5">
           <Button

--- a/src/pages/EventSuccess.tsx
+++ b/src/pages/EventSuccess.tsx
@@ -91,7 +91,7 @@ const EventSuccess = () => {
 
           <div className="mt-8 p-4 border border-border-subtle rounded-xl bg-bg-surface">
             <div className="text-[11px] font-mono text-text-secondary tracking-[0.8px] uppercase">
-              EVENT · {eventName.toUpperCase()}
+              {TEXT.event.breadcrumb} · {eventName.toUpperCase()}
             </div>
             <div className="mt-4 flex flex-col items-center gap-4">
               <div className="bg-white border border-border-subtle rounded-sm p-3">


### PR DESCRIPTION
Fixes #157

Changes:
- Add `breadcrumb` label to `TEXT.ts`.
- Update `EventPage.tsx` to show `event.name` in the top breadcrumb.
- Update `EventSuccess.tsx` to use the localized breadcrumb label.
- Ensure all headers use uppercase for consistency with the design language.