### PR TITLE
[feature/ui-polish-hierarchy-errors] Improve hierarchy, errors, and modals

### DIFF
--- a/src/__tests__/auth/AuthRedirectFlow.test.tsx
+++ b/src/__tests__/auth/AuthRedirectFlow.test.tsx
@@ -158,11 +158,10 @@ describe("Auth redirect flow", () => {
       route: "/auth/callback",
     });
 
-    await waitFor(
-      () => {
-        expect(mockNavigate).toHaveBeenCalledWith("/auth");
-      },
-      { timeout: 3000 },
-    );
+    // With ErrorScreen, we no longer auto-redirect. We show a button.
+    expect(await screen.findByText(/Back to Sign In/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Back to Sign In/i }),
+    ).toHaveAttribute("href", "/auth");
   });
 });

--- a/src/components/ui/ErrorScreen.tsx
+++ b/src/components/ui/ErrorScreen.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, RefreshCcw } from "lucide-react";
+
+interface ErrorScreenProps {
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+  backPath?: string;
+  backLabel?: string;
+}
+
+export const ErrorScreen: React.FC<ErrorScreenProps> = ({
+  title = "Something went wrong",
+  message = "An unexpected error occurred. Please try again or return home.",
+  onRetry,
+  backPath = "/",
+  backLabel = "Return Home",
+}) => {
+  return (
+    <div className="min-h-screen bg-bg-base flex items-center justify-center p-6">
+      <div className="w-full max-w-[320px] text-center">
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-state-error-bg text-state-error mb-6">
+          <RefreshCcw className="h-6 w-6" />
+        </div>
+
+        <h1 className="text-[24px] font-semibold tracking-[-0.6px] leading-tight text-text-primary">
+          {title}
+        </h1>
+
+        <p className="text-[14px] text-text-secondary mt-3 mb-8 leading-relaxed">
+          {message}
+        </p>
+
+        <div className="flex flex-col gap-3">
+          {onRetry && (
+            <Button
+              variant="primary"
+              size="lg"
+              className="w-full gap-2"
+              onClick={onRetry}
+            >
+              <RefreshCcw className="h-4 w-4" />
+              Try again
+            </Button>
+          )}
+
+          <Button
+            asChild
+            variant={onRetry ? "ghost" : "primary"}
+            size="lg"
+            className="w-full gap-2"
+          >
+            <Link to={backPath}>
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              {backLabel}
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -5,6 +5,7 @@ import { useMyProfile } from "@/hooks/useProfile";
 import { useToast } from "@/hooks/use-toast";
 import { TEXT } from "@/constants/text";
 import { LoadingScreen } from "@/components/ui/LoadingScreen";
+import { ErrorScreen } from "@/components/ui/ErrorScreen";
 import { isSafeRedirect } from "@/lib/utils";
 import { analytics } from "@/lib/analytics";
 import { logger } from "@/lib/logger";
@@ -39,13 +40,7 @@ const AuthCallback = () => {
         category: "Auth",
         extra: { errorDescription },
       });
-      toast({
-        variant: "destructive",
-        title: "Error",
-        description: errorDescription || TEXT.authCallback.toast.genericFailure,
-      });
       setStatus("error");
-      setTimeout(() => navigate("/auth"), 2000);
       return;
     }
 
@@ -58,21 +53,15 @@ const AuthCallback = () => {
       }
 
       if (event === "SIGNED_OUT" || (!session && event !== "INITIAL_SESSION")) {
-        toast({
-          variant: "destructive",
-          title: "Error",
-          description: TEXT.authCallback.toast.noSession,
-        });
         setStatus("error");
         subscription.unsubscribe();
-        setTimeout(() => navigate("/auth"), 2000);
       }
     });
 
     return () => {
       subscription.unsubscribe();
     };
-  }, [location.search, navigate, toast]);
+  }, [location.search]);
 
   useEffect(() => {
     if (!userId || isProfileLoading || hasHandledProfile) {
@@ -81,14 +70,8 @@ const AuthCallback = () => {
 
     if (profileError) {
       logger.error(profileError, { category: "Auth" });
-      toast({
-        variant: "destructive",
-        title: "Error",
-        description: TEXT.authCallback.toast.loadProfileFailure,
-      });
       setStatus("error");
       setHasHandledProfile(true);
-      setTimeout(() => navigate("/auth"), 2000);
       return;
     }
 
@@ -111,26 +94,22 @@ const AuthCallback = () => {
     _profile?.name,
   ]);
 
-  if (status === "loading") {
+  if (status === "error") {
     return (
-      <LoadingScreen
-        title={TEXT.authCallback.loadingTitle}
-        message={TEXT.authCallback.loadingDescription}
+      <ErrorScreen
+        title={TEXT.authCallback.errorTitle}
+        message={TEXT.authCallback.errorDescription}
+        backPath="/auth"
+        backLabel="Back to Sign In"
       />
     );
   }
 
   return (
-    <div className="min-h-screen bg-bg-base flex items-center justify-center p-4">
-      <div className="text-center w-full max-w-[320px]">
-        <h1 className="text-[20px] font-semibold tracking-[-0.4px] text-state-error">
-          {TEXT.authCallback.errorTitle}
-        </h1>
-        <p className="text-[13px] text-text-secondary mt-2">
-          {TEXT.authCallback.errorDescription}
-        </p>
-      </div>
-    </div>
+    <LoadingScreen
+      title={TEXT.authCallback.loadingTitle}
+      message={TEXT.authCallback.loadingDescription}
+    />
   );
 };
 

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -384,7 +384,9 @@ const EventPage = () => {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-44">
-                <DropdownMenuItem onSelect={() => setShowQRDialog(true)}>
+                <DropdownMenuItem
+                  onSelect={() => setTimeout(() => setShowQRDialog(true), 0)}
+                >
                   <QrCode className="mr-2 h-4 w-4" aria-hidden="true" />
                   {TEXT.common.buttons.viewQrCode}
                 </DropdownMenuItem>
@@ -410,7 +412,9 @@ const EventPage = () => {
                   {TEXT.event.header.edit}
                 </DropdownMenuItem>
                 <DropdownMenuItem
-                  onSelect={() => setShowDeleteDialog(true)}
+                  onSelect={() =>
+                    setTimeout(() => setShowDeleteDialog(true), 0)
+                  }
                   className="text-state-error focus:text-state-error focus:bg-state-error-bg"
                 >
                   <Trash2 className="mr-2 h-4 w-4" aria-hidden="true" />

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -79,19 +79,26 @@ const Landing = () => {
               <Button variant="ghost" size="sm" onClick={handleSignOut}>
                 Sign out
               </Button>
+              <Link to="/create-event">
+                <Button variant="primary" size="sm">
+                  Create event
+                </Button>
+              </Link>
             </>
           ) : (
-            <Link to="/auth">
-              <Button variant="ghost" size="sm">
-                Sign in
-              </Button>
-            </Link>
+            <>
+              <Link to="/join-event">
+                <Button variant="ghost" size="sm">
+                  Join event
+                </Button>
+              </Link>
+              <Link to="/auth">
+                <Button variant="primary" size="sm">
+                  Sign in
+                </Button>
+              </Link>
+            </>
           )}
-          <Link to={user ? "/create-event" : "/auth"}>
-            <Button variant="primary" size="sm">
-              Create event
-            </Button>
-          </Link>
         </div>
       </header>
 
@@ -118,6 +125,13 @@ const Landing = () => {
                   {user ? "Create your first event" : "Sign in with LinkedIn"}
                 </Button>
               </Link>
+              {!user && (
+                <Link to="/join-event">
+                  <Button variant="outline" size="lg" className="px-10 h-12">
+                    Join with code
+                  </Button>
+                </Link>
+              )}
             </div>
           </div>
         </section>

--- a/src/pages/event/components/EventHeader.tsx
+++ b/src/pages/event/components/EventHeader.tsx
@@ -270,7 +270,7 @@ const EventHeader = ({
                 )}
                 {onDelete && (
                   <DropdownMenuItem
-                    onSelect={() => onDelete()}
+                    onSelect={() => setTimeout(() => onDelete(), 0)}
                     className="text-destructive focus:text-destructive"
                   >
                     <Trash2 className="mr-2 h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
Fixes #147, #149, #160

Changes:
- **Hierarchy (#147)**: Refactor Landing page CTAs. Guest users now see 'Sign in' (primary) and 'Join Event' (ghost/outline). 'Create Event' is reserved for authenticated users.
- **Errors (#149)**: Introduce `ErrorScreen` component. Update `AuthCallback` to use it with actionable 'Back to Sign In' path.
- **Modals (#160)**: Add micro-delays to dropdown actions to prevent overlay layering issues.
- **Tests**: Update `AuthRedirectFlow.test.tsx` to match new error UX.