### PR TITLE
[chore] Add AI review assignment workflow

### DIFF
--- a/.gemini/skills/github-pr-protocol/SKILL.md
+++ b/.gemini/skills/github-pr-protocol/SKILL.md
@@ -7,7 +7,7 @@ description: Maintain and review GitHub PRs according to the project's AI review
 
 ## Overview
 
-This skill ensures all contributions follow the linked-list project's strict PR maintenance and review lifecycle. It prioritizes single-commit atomicity, mandatory signing, and the "Reply to Every Thread" AI review protocol.
+This skill ensures all contributions follow the linked-list project's strict PR maintenance and review lifecycle. `WORKFLOW.md` is the source of truth for GitHub signaling, AI review assignment, labels, PR body metadata, and merge rules.
 
 ## PR Maintenance Workflow
 
@@ -18,6 +18,7 @@ Gather the full picture of open pull requests.
 ```bash
 gh pr list
 gh pr view <number> --json reviewDecision,statusCheckRollup,reviews
+./scripts/next-ai-review.sh gemini
 ```
 
 ### 2. Feedback Retrieval
@@ -40,13 +41,15 @@ Check for adherence to core mandates:
 
 When addressing feedback:
 
-1. **Analyze**: Review every individual comment thread.
-2. **Reply**: Use `gh pr comment <number> --body "..."` to acknowledge or resolve every thread.
-3. **Refine**: Clean up the PR branch using `git commit --amend` or `git rebase -i` to maintain a single commit.
-4. **Sign**: Ensure the final amended commit is signed.
+1. **Claim**: Run `./scripts/next-ai-review.sh gemini --claim` before starting review work.
+2. **Analyze**: Review every individual comment thread.
+3. **Reply**: Use threaded replies for every thread that needs a response.
+4. **Refine**: Clean up the PR branch using `git commit --amend` or `git rebase -i` to maintain a single commit.
+5. **Sign**: Ensure the final amended commit is signed.
 
 ## Key Constraints
 
 - **No Squash-Merge**: Never use the GitHub UI to squash-merge.
 - **Merge Commits Only**: Standard merge commits are the only allowed way to bring code into `main`.
 - **Docs**: Always check if behavior changes require documentation updates in `README.md` or `CLAUDE.md`.
+- **No Self-Review**: Do not review Gemini-authored PRs unless the user explicitly asks for a self-audit.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,12 @@
 
 ## Changes
 
+## Tests
+
 ## Notes
+
+## AI Metadata
+
+Author-Agent:
+Review-Status:
+Review-Claimed-By:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Instructions
+
+All AI agents must follow the shared process in `WORKFLOW.md`.
+
+## Required Reading
+
+- `WORKFLOW.md` for GitHub workflow, PR signaling, review assignment, and merge rules.
+- `CONTRIBUTING.md` for contributor-facing summary rules.
+- `DEFINITION_OF_DONE.md` and `QA_CHECKLIST.md` before marking work complete.
+- `PROJECT_CONTEXT.md` for architecture and product context.
+
+## Agent Review Assignment
+
+Use `./scripts/next-ai-review.sh <codex|claude|gemini>` to find reviewable PRs. Use `--claim` before starting review work so another agent does not duplicate the same review.
+
+Do not review PRs authored by your same agent identity unless the user explicitly asks for a self-audit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # AI Agent Guidelines
 
+Shared GitHub workflow, PR signaling, review assignment, and merge rules live in `WORKFLOW.md`. Follow that file first when rules overlap.
+
 ## Branching
 
 - **NO DIRECT COMMITS TO MAIN:** Under no circumstances should any code be committed directly to the `main` branch.
@@ -29,6 +31,15 @@
 ## PR Descriptions
 
 Always use `.github/pull_request_template.md`. When using `gh pr create`, do not pass `--body` — let GitHub auto-populate the template, then fill in every section.
+
+PR descriptions must not be empty. They must summarize the git diff and relevant test results. Agent-authored PRs must fill in `Author-Agent`, `Review-Status`, and `Review-Claimed-By` metadata from `WORKFLOW.md`.
+
+## AI Review Assignment
+
+- Use `./scripts/next-ai-review.sh claude` to find the next open PR Claude can review.
+- Use `./scripts/next-ai-review.sh claude --claim` before starting review work.
+- Do not self-review Claude-authored PRs unless the user explicitly asks for a self-audit.
+- A claim means adding `🤖 ai-reviewing` and setting `Review-Status: claimed` with `Review-Claimed-By: claude`.
 
 ## Before Opening a PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+`WORKFLOW.md` is the source of truth for GitHub workflow, AI PR signaling, and review assignment. This file is the short contributor checklist.
+
 ## Team
 
 - Harry Denell (@harryden)
@@ -23,13 +25,17 @@
 - Rebased, no conflicts
 - CI green (lint, typecheck, test, build)
 - Docs updated if behavior changed
+- PR description is filled out, summarizes the git diff, and includes relevant test results
+- Agent-authored PRs include AI metadata and labels from `WORKFLOW.md`
 
 ## AI Review & Feedback Loop
 
-1. Wait for AI Review
-2. Review & take a stance
-3. Reply to every individual comment thread
-4. Clean up PR branch with amend/autosquash before final approval
+1. Mark ready PRs with `🤖 ai-ready-for-review`.
+2. Reviewers claim PRs explicitly with `🤖 ai-reviewing` before starting.
+3. Wait for AI Review.
+4. Review & take a stance.
+5. Reply to every individual comment thread.
+6. Clean up PR branch with amend/autosquash before final approval.
 
 ## Review & Merge
 

--- a/DEFINITION_OF_DONE.md
+++ b/DEFINITION_OF_DONE.md
@@ -19,7 +19,8 @@ This document defines the requirements that must be met before any feature or bu
 ## 3. Documentation
 
 - [ ] `README.md` or `PROJECT_CONTEXT.md` updated if architecture changed.
-- [ ] PR description follows the template and explains the "Why."
+- [ ] PR description follows the template, is not empty, summarizes the git diff, and includes relevant test results.
+- [ ] Agent-authored PRs include the required AI metadata and labels from `WORKFLOW.md`.
 
 ## 4. UI/UX & A11y
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,8 +1,14 @@
-See `CLAUDE.md` for all AI agent guidelines.
+See `WORKFLOW.md` for shared GitHub workflow, PR signaling, review assignment, and merge rules. See `CLAUDE.md` for additional AI agent guidelines.
 
 ## AI Agent Mandates
 
 - **Always Sign Commits**: Use GPG signing for every commit to ensure authenticity and maintain verified status in GitHub.
+
+## AI Review Assignment
+
+- Use `./scripts/next-ai-review.sh gemini` to find the next open PR Gemini can review.
+- Use `./scripts/next-ai-review.sh gemini --claim` before starting review work.
+- Do not self-review Gemini-authored PRs unless the user explicitly asks for a self-audit.
 
 ## Efficiency Mandates
 

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -19,3 +19,4 @@
 - No comments. Self-documentary code only.
 - Atomic commits. PRs required.
 - Copilot review required before merge.
+- Shared GitHub workflow and AI review assignment rules live in `WORKFLOW.md`.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,106 @@
+# Workflow
+
+This file is the shared source of truth for GitHub workflow, AI agent PR authorship, and AI review assignment.
+
+## Branches and Commits
+
+- Never commit directly to `main`.
+- Branch from latest `main` using `feature/<name>` or `chore/<name>`.
+- Rebase on `main` before opening a PR.
+- Keep each PR atomic and ideally exactly one commit.
+- Use imperative commit messages with a capital first letter: `Add event filters`.
+- Do not use type prefixes such as `fix:`, `feat:`, or `chore:`.
+- Use signed commits when available. Gemini-authored commits must be GPG signed.
+
+## Pull Requests
+
+- Use `.github/pull_request_template.md`.
+- PR descriptions must not be empty.
+- PR descriptions must summarize the git diff and relevant test results.
+- PR titles should use `[feature/<name>] Brief description` for feature branches and `[chore] Brief description` otherwise.
+- Every PR must pass independently without depending on another open PR.
+- Merge commits only. Do not squash merge or rebase merge on GitHub.
+- At least one approving review is required.
+- Wait for Copilot review before merge.
+- Reply to every individual review thread before merge. Do not replace threaded replies with a top-level summary comment.
+
+## Required Engineering Standards
+
+- SVG icons and inline SVGs must use `currentColor` for strokes/fills unless there is a documented product reason to hard-code a color.
+- Navigation or auth redirect targets must be validated with `isSafeRedirect` from `src/lib/utils.ts`.
+- Do not leave `console.log`, debug code, or commented-out code in PRs.
+- Add or update tests when behavior changes.
+- If Husky hooks fail only because the local Node version does not match the repo/CI version, an agent may use `--no-verify` as a temporary bypass. The PR description must mention the bypass and include the validation command results run manually.
+
+## AI PR Signaling
+
+Use labels and PR body metadata together. Labels make GitHub search easy. Metadata makes authorship and review state explicit even when labels are missing or stale.
+
+### Labels
+
+- `agent:codex`: PR authored by Codex.
+- `agent:claude`: PR authored by Claude.
+- `agent:gemini`: PR authored by Gemini.
+- `🤖 ai-ready-for-review`: PR author says the PR is ready for AI review.
+- `🤖 ai-reviewing`: an AI agent has claimed review work on the PR.
+
+Agents may create missing labels with:
+
+```bash
+gh label create "🤖 ai-ready-for-review" --color "0e8a16" --description "Ready for AI agent review"
+gh label create "🤖 ai-reviewing" --color "fbca04" --description "AI agent review is in progress"
+gh label create "agent:codex" --color "5319e7" --description "Authored by Codex"
+gh label create "agent:claude" --color "1d76db" --description "Authored by Claude"
+gh label create "agent:gemini" --color "c2e0c6" --description "Authored by Gemini"
+```
+
+### PR Body Metadata
+
+Every agent-authored PR must fill in the AI metadata section in the PR template:
+
+```text
+Author-Agent: codex|claude|gemini|human
+Review-Status: draft|ready|claimed|reviewed|changes-requested
+Review-Claimed-By:
+```
+
+Set `Author-Agent` to the authoring agent. Set `Review-Status: ready` when the PR is ready and add `🤖 ai-ready-for-review`. Leave `Review-Claimed-By` empty until a reviewer claims the PR.
+
+## Finding Review Work
+
+An AI reviewer should review open PRs that:
+
+- are not drafts,
+- have `🤖 ai-ready-for-review` or `Review-Status: ready`,
+- do not have that same agent's author label,
+- do not declare that same agent in `Author-Agent`,
+- do not have `🤖 ai-reviewing`, and
+- do not have `Review-Status: claimed`.
+
+Use the helper script:
+
+```bash
+./scripts/next-ai-review.sh codex
+./scripts/next-ai-review.sh claude
+./scripts/next-ai-review.sh gemini
+```
+
+To claim the next reviewable PR:
+
+```bash
+./scripts/next-ai-review.sh codex --claim
+```
+
+Claiming adds `🤖 ai-reviewing` and writes `Review-Status: claimed` plus `Review-Claimed-By: <agent>` to the PR body. This avoids duplicate AI review work.
+
+## Completing Review Work
+
+After reviewing:
+
+- leave a GitHub review with findings or approval,
+- remove `🤖 ai-reviewing`,
+- update `Review-Status` to `reviewed` or `changes-requested`,
+- keep `🤖 ai-ready-for-review` if the PR still needs another review pass,
+- remove `🤖 ai-ready-for-review` only when the PR is no longer seeking AI review.
+
+Do not self-review unless the user explicitly asks for a self-audit. A self-audit is not a substitute for the required approving review.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "review:next": "scripts/next-ai-review.sh"
   },
   "dependencies": {
     "@fontsource/geist-mono": "^5.2.7",

--- a/scripts/next-ai-review.sh
+++ b/scripts/next-ai-review.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <codex|claude|gemini> [--claim]" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 2
+fi
+
+agent="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+claim="${2:-}"
+
+case "$agent" in
+  codex | claude | gemini) ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+if [[ -n "$claim" && "$claim" != "--claim" ]]; then
+  usage
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI is required: https://cli.github.com/" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "GitHub CLI is not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
+
+jq_filter='
+  def label_names: [.labels[].name];
+  def metadata($key):
+    (.body // "" | capture("(?im)^" + $key + ":\\s*(?<value>[^\\r\\n]*)").value? // "");
+  def normalized($value): ($value // "" | ascii_downcase | gsub("^\\s+|\\s+$"; ""));
+
+  [
+    .[]
+    | .labelNames = label_names
+    | .authorAgent = normalized(metadata("Author-Agent"))
+    | .reviewStatus = normalized(metadata("Review-Status"))
+    | select(.isDraft | not)
+    | select((.labelNames | index("agent:'"$agent"'") | not) and (.authorAgent != "'"$agent"'"))
+    | select((.labelNames | index("🤖 ai-ready-for-review")) or .reviewStatus == "ready")
+    | select((.labelNames | index("🤖 ai-reviewing") | not) and .reviewStatus != "claimed")
+  ]
+  | sort_by(.updatedAt)
+  | reverse
+  | .[0]
+  | if . == null then empty else
+      {
+        number,
+        title,
+        url,
+        headRefName,
+        author: .author.login,
+        authorAgent,
+        reviewStatus,
+        labels: .labelNames
+      }
+    end
+'
+
+candidate="$(
+  gh pr list \
+    --state open \
+    --limit 100 \
+    --json number,title,url,headRefName,isDraft,labels,body,author,updatedAt \
+    --jq "$jq_filter"
+)"
+
+if [[ -z "$candidate" ]]; then
+  echo "No reviewable PR found for $agent."
+  exit 0
+fi
+
+number="$(
+  printf '%s\n' "$candidate" | node -e '
+    let input = "";
+    process.stdin.on("data", (chunk) => (input += chunk));
+    process.stdin.on("end", () => {
+      const candidate = JSON.parse(input);
+      process.stdout.write(String(candidate.number));
+    });
+  '
+)"
+
+if [[ "$claim" == "--claim" ]]; then
+  body="$(gh pr view "$number" --json body --jq '.body // ""')"
+  updated_body="$(
+    printf '%s' "$body" | awk -v agent="$agent" '
+      BEGIN {
+        saw_status = 0
+        saw_claimed_by = 0
+      }
+      /^Review-Status:[[:space:]]*/ {
+        print "Review-Status: claimed"
+        saw_status = 1
+        next
+      }
+      /^Review-Claimed-By:[[:space:]]*/ {
+        print "Review-Claimed-By: " agent
+        saw_claimed_by = 1
+        next
+      }
+      { print }
+      END {
+        if (!saw_status) print "Review-Status: claimed"
+        if (!saw_claimed_by) print "Review-Claimed-By: " agent
+      }
+    '
+  )"
+
+  gh pr edit "$number" --add-label "🤖 ai-reviewing" --body "$updated_body" >/dev/null
+  echo "Claimed PR #$number for $agent review."
+fi
+
+printf '%s\n' "$candidate"


### PR DESCRIPTION
## Summary

Adds a lightweight AI review-assignment workflow so Codex, Claude, and Gemini can discover and claim reviewable PRs without manual prompting.

## Changes

- Adds `WORKFLOW.md` as the shared source of truth for GitHub workflow, AI PR signaling, labels, metadata, and review claiming.
- Adds `AGENTS.md` as the common agent entry point.
- Updates `CONTRIBUTING.md`, `CLAUDE.md`, `GEMINI.md`, `DEFINITION_OF_DONE.md`, `PROJECT_CONTEXT.md`, and the Gemini PR skill to point back to the shared workflow.
- Extends the PR template with `Tests` and explicit AI metadata fields.
- Adds `scripts/next-ai-review.sh` and `npm run review:next -- <agent>` for finding and optionally claiming the next reviewable PR.

## Tests

- `bash -n scripts/next-ai-review.sh`
- `git diff --check`
- `npx --no-install prettier --check WORKFLOW.md AGENTS.md CONTRIBUTING.md CLAUDE.md GEMINI.md DEFINITION_OF_DONE.md PROJECT_CONTEXT.md .github/pull_request_template.md .gemini/skills/github-pr-protocol/SKILL.md package.json`
- `./scripts/next-ai-review.sh codex`

## Notes

- The first `git push` ran the pre-push hook and found an unrelated pre-existing Prettier issue in `src/components/ui/button.tsx`. Per maintainer direction, that unrelated hook-created local change was discarded and this branch was pushed with `--no-verify` so this PR stays scoped to the workflow setup.
- No application code behavior changed.

## AI Metadata

Author-Agent: codex
Review-Status: ready
Review-Claimed-By:
