### PR TITLE
[feature/fix-196-feedback-modal-close] Close feedback modal when signing in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ vite.config.ts.timestamp-*
 .gstack/
 .vercel/
 test-results/
+.worktrees

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -117,7 +117,10 @@ export const FeedbackDialog = ({
 
         {isAuthenticated === false ? (
           <div className="pt-4">
-            <Link to={`/auth?next=${encodeURIComponent(location.pathname)}`}>
+            <Link
+              to={`/auth?next=${encodeURIComponent(location.pathname)}`}
+              onClick={() => setOpen(false)}
+            >
               <Button
                 className="w-full gap-2 py-6 text-base"
                 variant="linkedin"


### PR DESCRIPTION
## Summary

Fixes the feedback modal staying open when the user clicks "Sign in to send feedback". The modal now closes immediately before navigating to the auth page.

## Changes

- [`src/components/FeedbackDialog.tsx`](src/components/FeedbackDialog.tsx): Added `onClick={() => setOpen(false)}` to the `<Link>` that wraps the sign-in button, so the dialog closes before the auth redirect.

## Tests

Pre-existing test suite passes (1 pre-existing failure in JoinEvent unrelated to this change). No new test failures introduced.

## Notes

Previously the Radix UI `Dialog` stayed mounted after navigation because nothing called `setOpen(false)`. This change closes the dialog as part of the click handler before React Router navigates to `/auth`.

## AI Metadata

Author-Agent: claude
Review-Status: ready
Review-Claimed-By: