### PR TITLE
[feature/fix-144-auth-redirect-loop] Restore redirect destination through LinkedIn auth flow

### DIFF
--- a/src/__tests__/auth/AuthRedirectFlow.test.tsx
+++ b/src/__tests__/auth/AuthRedirectFlow.test.tsx
@@ -61,7 +61,7 @@ describe("Auth redirect flow", () => {
     });
 
     renderWithProviders(<Auth />, {
-      route: "/auth?redirect=/event/test-event",
+      route: "/auth?next=/event/test-event",
     });
 
     await user.click(
@@ -88,7 +88,7 @@ describe("Auth redirect flow", () => {
     });
 
     renderWithProviders(<Auth />, {
-      route: "/auth?redirect=https://malicious.example",
+      route: "/auth?next=https://malicious.example",
     });
 
     await user.click(

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -19,7 +19,7 @@ const Auth = () => {
 
   const redirectPath = useMemo(() => {
     const params = new URLSearchParams(location.search);
-    const fromQuery = params.get("redirect");
+    const fromQuery = params.get("next");
 
     if (isSafeRedirect(fromQuery)) {
       return fromQuery as string;

--- a/src/pages/CreateEvent.tsx
+++ b/src/pages/CreateEvent.tsx
@@ -104,7 +104,7 @@ const CreateEvent = () => {
           variant: "destructive",
           description: TEXT.createEvent.toast.authRequired,
         });
-        navigate("/auth");
+        navigate(`/auth?next=${encodeURIComponent(window.location.pathname)}`);
         return;
       }
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -42,7 +42,7 @@ const useSession = (navigate: NavigateFunction) => {
 
       if (isMounted) {
         if (!session) {
-          navigate("/auth");
+          navigate(`/auth?next=${encodeURIComponent(window.location.pathname)}`);
         } else {
           setUserId(session.user.id);
         }
@@ -57,7 +57,7 @@ const useSession = (navigate: NavigateFunction) => {
     } = supabase.auth.onAuthStateChange((_event, session) => {
       if (isMounted) {
         if (!session) {
-          navigate("/auth");
+          navigate(`/auth?next=${encodeURIComponent(window.location.pathname)}`);
         } else {
           setUserId(session?.user?.id ?? null);
         }

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -210,7 +210,7 @@ const EventPage = () => {
 
   const handleCheckIn = async () => {
     if (!currentUserId) {
-      navigate("/auth");
+      navigate(`/auth?next=${encodeURIComponent(window.location.pathname)}`);
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes the auth redirect loop where users always landed on `/` after signing in, regardless of which page they were trying to access.

## Changes

- [`src/pages/Auth.tsx`](src/pages/Auth.tsx): Changed `params.get("redirect")` → `params.get("next")` to match the param name used by callers (`AuthCallback`, `FeedbackDialog`, and now the protected pages below).
- [`src/pages/Dashboard.tsx`](src/pages/Dashboard.tsx): Changed both `navigate("/auth")` calls to include the current path as `?next=…`.
- [`src/pages/CreateEvent.tsx`](src/pages/CreateEvent.tsx): Same — passes current path to `/auth`.
- [`src/pages/EventPage.tsx`](src/pages/EventPage.tsx): Same — passes current path to `/auth`.

## Tests

Pre-existing test suite passes (1 pre-existing failure in JoinEvent unrelated to this change). Typecheck clean.

## Notes

Root cause: `Auth.tsx` was reading the `redirect` query param while every caller (including `FeedbackDialog` and `AuthCallback`) uses `next`. At the same time, protected pages were calling `navigate("/auth")` with no return-path param, so after OAuth the callback always landed on `/`. The fix aligns the param name and ensures all protected pages encode their pathname before sending the user to auth.

## AI Metadata

Author-Agent: claude
Review-Status: ready
Review-Claimed-By: