### PR TITLE
[feature/fix-146-feedback-stale-auth] Use getUser() in feedback mutation to prevent stale JWT inserts

### DIFF
--- a/src/__tests__/hooks/feedback.test.tsx
+++ b/src/__tests__/hooks/feedback.test.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useFeedback } from "@/hooks/useFeedback";
+import { createQueryStub, supabaseStub } from "@/test-utils/supabase";
+
+const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+
+  return { client, wrapper };
+};
+
+describe("useFeedback hook", () => {
+  it("uses getUser() to ensure a fresh session before inserting feedback", async () => {
+    const { wrapper } = createWrapper();
+    const user = { id: "user-123" };
+    
+    // Mock getUser() success
+    supabaseStub.auth.getUser.mockResolvedValue({
+      data: { user },
+      error: null,
+    });
+
+    const query = createQueryStub({ baseResult: { data: null, error: null } });
+    query.insert.mockReturnValue(query);
+
+    supabaseStub.from.mockImplementationOnce((table) => {
+      expect(table).toBe("feedback");
+      return query;
+    });
+
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+
+    await result.current.mutateAsync({
+      category: "general",
+      message: "Great app!",
+      page_path: "/dashboard",
+    });
+
+    // Verify getUser was called, not getSession
+    expect(supabaseStub.auth.getUser).toHaveBeenCalled();
+    expect(supabaseStub.auth.getSession).not.toHaveBeenCalled();
+
+    // Verify insert used the user ID from getUser()
+    expect(query.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user-123",
+        message: "Great app!",
+      })
+    );
+  });
+
+  it("throws an error if getUser() fails or returns no user", async () => {
+    const { wrapper } = createWrapper();
+    
+    // Mock getUser() failure
+    supabaseStub.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error("Auth error"),
+    });
+
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+
+    await expect(
+      result.current.mutateAsync({
+        category: "general",
+        message: "Great app!",
+        page_path: "/dashboard",
+      })
+    ).rejects.toThrow("Authentication required to submit feedback");
+  });
+});

--- a/src/hooks/useFeedback.ts
+++ b/src/hooks/useFeedback.ts
@@ -21,15 +21,16 @@ interface FeedbackInsert {
 export const useFeedback = () => {
   return useMutation({
     mutationFn: async (payload: FeedbackPayload) => {
-      const { data: sessionData } = await supabase.auth.getSession();
+      const { data: userData, error: userError } =
+        await supabase.auth.getUser();
 
-      if (!sessionData?.session) {
+      if (userError || !userData.user) {
         throw new Error("Authentication required to submit feedback");
       }
 
       const insert: FeedbackInsert = {
         ...payload,
-        user_id: sessionData.session.user.id,
+        user_id: userData.user.id,
         user_agent: window.navigator.userAgent,
       };
 


### PR DESCRIPTION
## Summary

Fixes feedback submissions failing with "Could not send feedback" when the user's access token has expired since the dialog was opened.

## Changes

- [`src/hooks/useFeedback.ts`](src/hooks/useFeedback.ts): Replaced `supabase.auth.getSession()` with `supabase.auth.getUser()`.

## Tests

Pre-existing test suite passes (1 pre-existing failure in JoinEvent unrelated to this change). Typecheck clean.

## Notes

`getSession()` returns the locally-cached session without touching the server. If the JWT has expired since the dialog was opened, `auth.uid()` in the RLS policy resolves to `null`, the insert is blocked with a policy violation (not an auth error), and the user sees "Could not send feedback."

`getUser()` makes a server-side validation call and triggers a token refresh when the JWT is stale. This ensures `auth.uid()` resolves correctly at insert time.

The RLS policy on the `feedback` table (`WITH CHECK (user_id = auth.uid())`) requires a valid, server-verified token — `getUser()` is the right call for this pattern.

## AI Metadata

Author-Agent: claude
Review-Status: changes-requested
Review-Claimed-By: