### PR TITLE
[feature/fix-146-feedback-stale-auth] Fix stale JWT inserts and network error masking

### DIFF
--- a/src/__tests__/hooks/feedback.test.tsx
+++ b/src/__tests__/hooks/feedback.test.tsx
@@ -1,0 +1,102 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useFeedback } from "@/hooks/useFeedback";
+import { createQueryStub, supabaseStub } from "@/test-utils/supabase";
+
+const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+
+  return { client, wrapper };
+};
+
+describe("useFeedback hook", () => {
+  it("uses getUser() to ensure a fresh session before inserting feedback", async () => {
+    const { wrapper } = createWrapper();
+    const user = { id: "user-123" };
+
+    // Mock getUser() success
+    supabaseStub.auth.getUser.mockResolvedValue({
+      data: { user },
+      error: null,
+    });
+
+    const query = createQueryStub({ baseResult: { data: null, error: null } });
+    query.insert.mockReturnValue(query);
+
+    supabaseStub.from.mockImplementationOnce((table) => {
+      expect(table).toBe("feedback");
+      return query;
+    });
+
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+
+    await result.current.mutateAsync({
+      category: "general",
+      message: "Great app!",
+      page_path: "/dashboard",
+    });
+
+    // Verify getUser was called, not getSession
+    expect(supabaseStub.auth.getUser).toHaveBeenCalled();
+    expect(supabaseStub.auth.getSession).not.toHaveBeenCalled();
+
+    // Verify insert used the user ID from getUser()
+    expect(query.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user-123",
+        message: "Great app!",
+      }),
+    );
+  });
+
+  it("throws the original error for network failures", async () => {
+    const { wrapper } = createWrapper();
+
+    // Mock getUser() failure
+    supabaseStub.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error("Network error"),
+    });
+
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+
+    await expect(
+      result.current.mutateAsync({
+        category: "general",
+        message: "Great app!",
+        page_path: "/dashboard",
+      }),
+    ).rejects.toThrow("Network error");
+  });
+
+  it("throws authentication error if getUser() returns an auth error or no user", async () => {
+    const { wrapper } = createWrapper();
+
+    const authError = new Error("Auth Error");
+    authError.name = "AuthSessionMissingError";
+
+    // Mock getUser() failure
+    supabaseStub.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: authError,
+    });
+
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+
+    await expect(
+      result.current.mutateAsync({
+        category: "general",
+        message: "Great app!",
+        page_path: "/dashboard",
+      }),
+    ).rejects.toThrow("Authentication required to submit feedback");
+  });
+});

--- a/src/hooks/useFeedback.ts
+++ b/src/hooks/useFeedback.ts
@@ -21,15 +21,26 @@ interface FeedbackInsert {
 export const useFeedback = () => {
   return useMutation({
     mutationFn: async (payload: FeedbackPayload) => {
-      const { data: sessionData } = await supabase.auth.getSession();
+      const { data: userData, error: userError } =
+        await supabase.auth.getUser();
 
-      if (!sessionData?.session) {
+      if (userError) {
+        if (
+          userError.name === "AuthSessionMissingError" ||
+          userError.status === 401
+        ) {
+          throw new Error("Authentication required to submit feedback");
+        }
+        throw userError;
+      }
+
+      if (!userData?.user) {
         throw new Error("Authentication required to submit feedback");
       }
 
       const insert: FeedbackInsert = {
         ...payload,
-        user_id: sessionData.session.user.id,
+        user_id: userData.user.id,
         user_agent: window.navigator.userAgent,
       };
 

--- a/src/pages/CreateEvent.tsx
+++ b/src/pages/CreateEvent.tsx
@@ -96,10 +96,11 @@ const CreateEvent = () => {
   const onSubmit = async (values: CreateEventValues) => {
     try {
       const {
-        data: { session },
-      } = await supabase.auth.getSession();
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
 
-      if (!session) {
+      if (userError || !user) {
         toast({
           variant: "destructive",
           description: TEXT.createEvent.toast.authRequired,
@@ -176,7 +177,7 @@ const CreateEvent = () => {
           starts_at: normalizedStartsAt,
           ends_at: normalizedEndsAt,
           linkedin_event_url: values.linkedinUrl || null,
-          organizer_id: session.user.id,
+          organizer_id: user.id,
         });
 
         analytics.track("event_created", { slug });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -42,7 +42,9 @@ const useSession = (navigate: NavigateFunction) => {
 
       if (isMounted) {
         if (!session) {
-          navigate(`/auth?next=${encodeURIComponent(window.location.pathname)}`);
+          navigate(
+            `/auth?next=${encodeURIComponent(window.location.pathname)}`,
+          );
         } else {
           setUserId(session.user.id);
         }
@@ -57,7 +59,9 @@ const useSession = (navigate: NavigateFunction) => {
     } = supabase.auth.onAuthStateChange((_event, session) => {
       if (isMounted) {
         if (!session) {
-          navigate(`/auth?next=${encodeURIComponent(window.location.pathname)}`);
+          navigate(
+            `/auth?next=${encodeURIComponent(window.location.pathname)}`,
+          );
         } else {
           setUserId(session?.user?.id ?? null);
         }

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -214,6 +214,16 @@ const EventPage = () => {
       return;
     }
 
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      navigate(`/auth?next=${encodeURIComponent(window.location.pathname)}`);
+      return;
+    }
+
     if (!event?.id) {
       toast({
         variant: "destructive",


### PR DESCRIPTION
This PR re-introduces the fixes from PR #200 (which was reverted) and addresses the remaining issues:

1. **Error Masking:** Differentiates between true `AuthSessionMissingError`/`401` and standard network errors in `useFeedback`.
2. **Incomplete Scope:** Swaps `getSession()` for `getUser()` in `CreateEvent.tsx` and `EventPage.tsx` to ensure fresh sessions right before mutations.
3. **Vercel Deployments:** Commits are authored by Harry Denell to resolve Vercel deployment block.

Fixes #146\n\n## AI Metadata\n\nAuthor-Agent: gemini\nReview-Status: ready\nReview-Claimed-By: