### PR TITLE
[feature/fix-143-auth-flow] Recover from stale auth route chunks

### DIFF
--- a/src/__tests__/auth/AuthRedirectFlow.test.tsx
+++ b/src/__tests__/auth/AuthRedirectFlow.test.tsx
@@ -79,6 +79,33 @@ describe("Auth redirect flow", () => {
     });
   });
 
+  it("preserves a legacy redirect path when starting OAuth", async () => {
+    const user = userEvent.setup();
+    configureSignIn();
+    getSessionMock.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    renderWithProviders(<Auth />, {
+      route: "/auth?redirect=/event/test-event",
+    });
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: new RegExp(TEXT.auth.card.buttonIdle, "i"),
+      }),
+    );
+
+    expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+      provider: "linkedin_oidc",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback?next=%2Fevent%2Ftest-event`,
+        scopes: "openid profile email",
+      },
+    });
+  });
+
   it("falls back to root when the redirect path is unsafe", async () => {
     const user = userEvent.setup();
     configureSignIn();
@@ -116,6 +143,25 @@ describe("Auth redirect flow", () => {
 
     renderWithProviders(<AuthCallback />, {
       route: "/auth/callback?next=%2Fevent%2Ftest-event",
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/event/test-event", {
+        replace: true,
+      });
+    });
+  });
+
+  it("navigates to a legacy redirect path encoded in the callback URL on successful auth", async () => {
+    mockNavigate.mockReset();
+
+    onAuthStateChangeMock.mockImplementation((cb) => {
+      queueMicrotask(() => cb("SIGNED_IN", { user: { id: "user_test" } }));
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+
+    renderWithProviders(<AuthCallback />, {
+      route: "/auth/callback?redirect=%2Fevent%2Ftest-event",
     });
 
     await waitFor(() => {

--- a/src/__tests__/lib/chunkReload.test.ts
+++ b/src/__tests__/lib/chunkReload.test.ts
@@ -1,0 +1,26 @@
+import { isChunkLoadError } from "@/lib/chunkReload";
+import { describe, expect, it } from "vitest";
+
+describe("chunk reload detection", () => {
+  it("detects browser dynamic import failure messages", () => {
+    expect(
+      isChunkLoadError(
+        new Error(
+          "Failed to fetch dynamically imported module: /assets/Auth.js",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isChunkLoadError(new Error("Importing a module script failed")),
+    ).toBe(true);
+    expect(
+      isChunkLoadError(
+        new Error("error loading dynamically imported module: /assets/Auth.js"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat unrelated render errors as chunk load errors", () => {
+    expect(isChunkLoadError(new Error("Generic component error"))).toBe(false);
+  });
+});

--- a/src/__tests__/smoke/AttendButton.test.tsx
+++ b/src/__tests__/smoke/AttendButton.test.tsx
@@ -57,9 +57,6 @@ describe("AttendButton smoke", () => {
       name: /check in with linkedin/i,
     });
 
-    expect(link).toHaveAttribute(
-      "href",
-      "/auth?redirect=%2Fevent%2Ftest-event",
-    );
+    expect(link).toHaveAttribute("href", "/auth?next=%2Fevent%2Ftest-event");
   });
 });

--- a/src/__tests__/ui/AttendButton.contract.test.tsx
+++ b/src/__tests__/ui/AttendButton.contract.test.tsx
@@ -117,7 +117,7 @@ describe("AttendButton contract", () => {
       name: TEXT.event.attendButton.checkInLinkedIn,
     });
 
-    expect(link).toHaveAttribute("href", "/auth?redirect=%2F");
+    expect(link).toHaveAttribute("href", "/auth?next=%2F");
   });
 
   it("invokes the supplied check-in handler when the user is authenticated", async () => {

--- a/src/__tests__/ui/ErrorBoundary.test.tsx
+++ b/src/__tests__/ui/ErrorBoundary.test.tsx
@@ -1,0 +1,151 @@
+import { renderWithProviders } from "@/test-utils/render";
+import { screen, waitFor } from "@testing-library/react";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import { CHUNK_ERROR_RELOAD_KEY } from "@/lib/chunkReload";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("ErrorBoundary", () => {
+  const originalLocation = window.location;
+  const originalSessionStorage = window.sessionStorage;
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    reload.mockReset();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload },
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: originalSessionStorage,
+    });
+    sessionStorage.clear();
+    vi.spyOn(console, "group").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "dir").mockImplementation(() => {});
+    vi.spyOn(console, "groupEnd").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: originalSessionStorage,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("reloads once when a lazy route chunk is stale after deployment", async () => {
+    const ThrowingComponent = () => {
+      const error = new Error("Loading chunk 123 failed");
+      error.name = "ChunkLoadError";
+      throw error;
+    };
+
+    renderWithProviders(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+  });
+
+  it("shows the fallback when chunk reload already happened recently", () => {
+    sessionStorage.setItem(
+      CHUNK_ERROR_RELOAD_KEY,
+      (Date.now() - 1000).toString(),
+    );
+
+    const ThrowingComponent = () => {
+      const error = new Error("Loading chunk 123 failed");
+      error.name = "ChunkLoadError";
+      throw error;
+    };
+
+    renderWithProviders(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("reloads when a dynamic import fetch fails", async () => {
+    const ThrowingComponent = () => {
+      throw new Error(
+        "Failed to fetch dynamically imported module: /assets/Auth.js",
+      );
+    };
+
+    renderWithProviders(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+  });
+
+  it("reloads when a module script import fails", async () => {
+    const ThrowingComponent = () => {
+      throw new Error("Importing a module script failed");
+    };
+
+    renderWithProviders(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+  });
+
+  it("shows the fallback when storage blocks the reload guard", () => {
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: {
+        clear: vi.fn(),
+        getItem: vi.fn(() => {
+          throw new Error("Storage unavailable");
+        }),
+        setItem: vi.fn(),
+      },
+    });
+
+    const ThrowingComponent = () => {
+      const error = new Error("Loading chunk 123 failed");
+      error.name = "ChunkLoadError";
+      throw error;
+    };
+
+    renderWithProviders(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("shows the fallback for non-deployment rendering errors", () => {
+    const ThrowingComponent = () => {
+      throw new Error("Generic component error");
+    };
+
+    renderWithProviders(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import { Button } from "@/components/ui/button";
 import { AlertTriangle, MessageSquare } from "lucide-react";
 import { FeedbackDialog } from "@/components/FeedbackDialog";
+import { canReloadForChunkError, isChunkLoadError } from "@/lib/chunkReload";
 
 interface Props {
   children: ReactNode;
@@ -10,18 +11,28 @@ interface Props {
 
 interface State {
   hasError: boolean;
+  shouldReload: boolean;
 }
 
 class ErrorBoundary extends Component<Props, State> {
   public state: State = {
     hasError: false,
+    shouldReload: false,
   };
 
-  public static getDerivedStateFromError(_: Error): State {
-    return { hasError: true };
+  public static getDerivedStateFromError(): State {
+    return { hasError: true, shouldReload: false };
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    if (isChunkLoadError(error)) {
+      if (canReloadForChunkError()) {
+        this.setState({ hasError: true, shouldReload: true });
+        window.location.reload();
+      }
+      return;
+    }
+
     logger.error(error, {
       category: "UI",
       extra: { componentStack: errorInfo.componentStack },
@@ -33,6 +44,10 @@ class ErrorBoundary extends Component<Props, State> {
   };
 
   public render() {
+    if (this.state.shouldReload) {
+      return null;
+    }
+
     if (this.state.hasError) {
       return (
         <div className="min-h-screen flex items-center justify-center p-4 bg-background">

--- a/src/lib/chunkReload.ts
+++ b/src/lib/chunkReload.ts
@@ -1,0 +1,30 @@
+export const CHUNK_ERROR_RELOAD_KEY = "last-chunk-error-reload";
+
+const CHUNK_ERROR_RELOAD_WINDOW_MS = 10000;
+
+export const isChunkLoadError = (error: Error) =>
+  error.name === "ChunkLoadError" ||
+  error.message.includes("Failed to fetch dynamically imported module") ||
+  error.message.includes("Importing a module script failed") ||
+  error.message.includes("error loading dynamically imported module");
+
+export const canReloadForChunkError = () => {
+  try {
+    const lastReload = sessionStorage.getItem(CHUNK_ERROR_RELOAD_KEY);
+    const lastReloadAt = lastReload ? Number.parseInt(lastReload, 10) : null;
+    const now = Date.now();
+
+    if (
+      !lastReloadAt ||
+      Number.isNaN(lastReloadAt) ||
+      now - lastReloadAt > CHUNK_ERROR_RELOAD_WINDOW_MS
+    ) {
+      sessionStorage.setItem(CHUNK_ERROR_RELOAD_KEY, now.toString());
+      return true;
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+};

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -19,7 +19,7 @@ const Auth = () => {
 
   const redirectPath = useMemo(() => {
     const params = new URLSearchParams(location.search);
-    const fromQuery = params.get("next");
+    const fromQuery = params.get("next") ?? params.get("redirect");
 
     if (isSafeRedirect(fromQuery)) {
       return fromQuery as string;

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -20,7 +20,7 @@ const AuthCallback = () => {
 
   const redirectPath = (() => {
     const params = new URLSearchParams(location.search);
-    const next = params.get("next");
+    const next = params.get("next") ?? params.get("redirect");
     return isSafeRedirect(next) ? (next as string) : "/";
   })();
 

--- a/src/pages/event/components/AttendButton.tsx
+++ b/src/pages/event/components/AttendButton.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { CheckCircle2, ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "framer-motion";
-import { cn } from "@/lib/utils";
+import { cn, isSafeRedirect } from "@/lib/utils";
 import { TEXT } from "@/constants/text";
 
 interface AttendButtonProps {
@@ -118,8 +118,8 @@ const AttendButton = ({
   );
 
   if (!currentUserId) {
-    const safeRedirectPath = redirectPath?.startsWith("/") ? redirectPath : "/";
-    const authLink = `/auth?redirect=${encodeURIComponent(safeRedirectPath)}`;
+    const safeRedirectPath = isSafeRedirect(redirectPath) ? redirectPath : "/";
+    const authLink = `/auth?next=${encodeURIComponent(safeRedirectPath)}`;
     return <Link to={authLink}>{button}</Link>;
   }
 


### PR DESCRIPTION
## Summary

Fixes #143. Recovers automatically from stale lazy-route chunk failures that previously dropped users onto the global error screen until they manually refreshed. Also keeps auth return paths consistent by standardizing new unauthenticated check-in links on `next` while still accepting legacy `redirect` parameters.

## Changes

- detect Vite/chunk dynamic import failures in `ErrorBoundary` and hard-reload once with a 10 second loop guard
- keep the normal fallback error screen for persistent chunk failures, blocked storage, and unrelated render errors
- cover Chrome, Safari, and Firefox dynamic import failure messages
- skip shipping recoverable chunk errors to the generic UI logger
- accept both `next` and legacy `redirect` auth return parameters in `/auth` and `/auth/callback`
- emit unauthenticated attend links as `/auth?next=...`
- add regression coverage for chunk recovery and auth redirect preservation
- rebased onto current `main` after #220 so this PR now contains only the #143 auth recovery work
- squashed back to one atomic commit after review follow-up

## Tests

- `npm run test:run -- src/__tests__/lib/chunkReload.test.ts src/__tests__/ui/ErrorBoundary.test.tsx src/__tests__/auth/AuthRedirectFlow.test.tsx src/__tests__/ui/AttendButton.contract.test.tsx src/__tests__/smoke/AttendButton.test.tsx`
- `PATH=/opt/homebrew/bin:$PATH CI=true VITE_PUBLIC_SUPABASE_URL=https://dummy.supabase.co VITE_PUBLIC_SUPABASE_ANON_KEY=dummy-key npx --no-install playwright test e2e/auth.spec.ts e2e/critical-flows.spec.ts`
- normal `git push` pre-push hook passed: Prettier, `npm run lint` (passes with 7 existing warnings), `npm run typecheck`, `npm run test:run`, `npm run build`

## AI Metadata

Author-Agent: codex
Review-Status: ready
Review-Claimed-By:
