### PR TITLE
[chore] Keep critical-flow event fixtures upcoming

### DIFF
--- a/e2e/critical-flows.spec.ts
+++ b/e2e/critical-flows.spec.ts
@@ -31,8 +31,8 @@ const hostedEvent: MockEvent = {
   organizer_id: organizer.id,
   short_code: "FB2025",
   location: "Gothenburg",
-  starts_at: "2026-05-01T08:00:00.000Z",
-  ends_at: "2026-05-01T10:00:00.000Z",
+  starts_at: "2099-05-01T08:00:00.000Z",
+  ends_at: "2099-05-01T10:00:00.000Z",
 };
 
 const attendedEvent: MockEvent = {
@@ -42,8 +42,8 @@ const attendedEvent: MockEvent = {
   organizer_id: organizer.id,
   short_code: "CD2025",
   location: "Stockholm",
-  starts_at: "2026-05-03T18:00:00.000Z",
-  ends_at: "2026-05-03T20:00:00.000Z",
+  starts_at: "2099-05-03T18:00:00.000Z",
+  ends_at: "2099-05-03T20:00:00.000Z",
 };
 
 test.describe("Critical release flows", () => {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -40,8 +40,7 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }


### PR DESCRIPTION
## Summary

Fixes #219. Restores the failing main E2E check by moving the critical-flow dashboard event fixtures out of the past. The latest main run failed because the May 1 and May 3, 2026 fixture events are now past dates as of May 8, 2026, so the dashboard no longer renders them as upcoming events.

## Changes

- move the critical-flow dashboard event fixture dates to 2099
- include the existing Prettier-only cleanup for `src/components/ui/button.tsx` required by the repo pre-push hook

## Tests

- `PATH=/opt/homebrew/bin:$PATH CI=true VITE_PUBLIC_SUPABASE_URL=https://dummy.supabase.co VITE_PUBLIC_SUPABASE_ANON_KEY=dummy-key npx --no-install playwright test e2e/critical-flows.spec.ts`
- normal `git push` pre-push hook passed: Prettier, `npm run lint` (passes with 7 existing warnings), `npm run typecheck`, `npm run test:run`, `npm run build`

## AI Metadata

Author-Agent: codex
Review-Status: ready-to-merge
Review-Claimed-By: gemini
